### PR TITLE
Differentiate CT and MRI artifact handling

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import bpy
-from bpy.props import FloatProperty, PointerProperty
+from bpy.props import EnumProperty, FloatProperty, PointerProperty
 
 from .artifacts import (
     add_gaussian_noise,
@@ -12,7 +12,7 @@ from .artifacts import (
     add_ring_artifacts,
     apply_partial_volume_effect,
 )
-from .constants import MAX_HU_VALUE, MIN_HU_VALUE
+from .constants import MATERIAL_ITEMS, MAX_HU_VALUE, MIN_HU_VALUE
 from .dicom_export import export_voxel_grid_to_dicom
 from .operators import MESH_OT_export_dicom
 from .panels import (
@@ -23,7 +23,7 @@ from .panels import (
     VIEW3D_PT_dicomator_per_object_hu,
     VIEW3D_PT_dicomator_selection_info,
 )
-from .properties import DICOMatorProperties
+from .properties import DICOMatorProperties, update_object_material
 from .voxelization import voxelize_mesh, voxelize_objects_to_hu
 
 bl_info = {
@@ -68,10 +68,22 @@ def register() -> None:  # pragma: no cover - Blender registration
             precision=0,
         )
 
+    if not hasattr(bpy.types.Object, "dicomator_material"):
+        bpy.types.Object.dicomator_material = EnumProperty(
+            name="Material",
+            description="Select a predefined tissue/material",
+            items=MATERIAL_ITEMS,
+            default="CUSTOM",
+            update=update_object_material,
+        )
+
 
 def unregister() -> None:  # pragma: no cover - Blender registration
     if hasattr(bpy.types.Scene, "dicomator_props"):
         del bpy.types.Scene.dicomator_props
+
+    if hasattr(bpy.types.Object, "dicomator_material"):
+        del bpy.types.Object.dicomator_material
 
     if hasattr(bpy.types.Object, "dicomator_hu"):
         del bpy.types.Object.dicomator_hu

--- a/constants.py
+++ b/constants.py
@@ -8,6 +8,120 @@ DEFAULT_DENSITY = 0.0   # Default HU for objects unless overridden per-object
 MAX_HU_VALUE = 3071     # Max HU for 12-bit CT representations
 MIN_HU_VALUE = -1024    # Min HU (typical CT lower bound)
 
+# Imaging modality identifiers used when mapping tissue presets to intensities.
+MODALITY_CT = "CT"
+MODALITY_MRI_T1 = "MRI_T1"
+MODALITY_MRI_T2 = "MRI_T2"
+
+MRI_MODALITIES = {MODALITY_MRI_T1, MODALITY_MRI_T2}
+
+IMAGING_MODALITY_ITEMS = [
+    (MODALITY_CT, "CT", "Assign CT Hounsfield Units"),
+    (MODALITY_MRI_T1, "T1 MR", "Assign intensities for T1-weighted MRI"),
+    (MODALITY_MRI_T2, "T2 MR", "Assign intensities for T2-weighted MRI"),
+]
+
+# Tissue/material presets with representative intensities for each modality.
+MATERIAL_INTENSITIES = {
+    "AIR": {
+        MODALITY_CT: -1000,
+        MODALITY_MRI_T1: 0,
+        MODALITY_MRI_T2: 0,
+    },
+    "CORTICAL_BONE": {
+        MODALITY_CT: 1100,
+        MODALITY_MRI_T1: 10,
+        MODALITY_MRI_T2: 8,
+    },
+    "TRABECULAR_BONE": {
+        MODALITY_CT: 200,
+        MODALITY_MRI_T1: 190,
+        MODALITY_MRI_T2: 170,
+    },
+    "FAT": {
+        MODALITY_CT: -75,
+        MODALITY_MRI_T1: 210,
+        MODALITY_MRI_T2: 170,
+    },
+    "MUSCLE": {
+        MODALITY_CT: 50,
+        MODALITY_MRI_T1: 90,
+        MODALITY_MRI_T2: 80,
+    },
+    "LIVER": {
+        MODALITY_CT: 50,
+        MODALITY_MRI_T1: 100,
+        MODALITY_MRI_T2: 90,
+    },
+    "SPLEEN": {
+        MODALITY_CT: 50,
+        MODALITY_MRI_T1: 110,
+        MODALITY_MRI_T2: 120,
+    },
+    "KIDNEY_CORTEX": {
+        MODALITY_CT: 40,
+        MODALITY_MRI_T1: 110,
+        MODALITY_MRI_T2: 100,
+    },
+    "KIDNEY_MEDULLA": {
+        MODALITY_CT: 40,
+        MODALITY_MRI_T1: 90,
+        MODALITY_MRI_T2: 150,
+    },
+    "CARTILAGE": {
+        MODALITY_CT: 200,
+        MODALITY_MRI_T1: 100,
+        MODALITY_MRI_T2: 130,
+    },
+    "BLOOD_ACUTE": {
+        MODALITY_CT: 60,
+        MODALITY_MRI_T1: 130,
+        MODALITY_MRI_T2: 30,
+    },
+    "WHITE_MATTER": {
+        MODALITY_CT: 25,
+        MODALITY_MRI_T1: 150,
+        MODALITY_MRI_T2: 50,
+    },
+    "GRAY_MATTER": {
+        MODALITY_CT: 40,
+        MODALITY_MRI_T1: 110,
+        MODALITY_MRI_T2: 110,
+    },
+    "CSF_WATER": {
+        MODALITY_CT: 0,
+        MODALITY_MRI_T1: 30,
+        MODALITY_MRI_T2: 230,
+    },
+}
+
+MATERIAL_ITEMS = [
+    ("CUSTOM", "Custom", "Manually specify an intensity value"),
+    ("AIR", "Air", "No signal"),
+    ("CORTICAL_BONE", "Cortical Bone / Calcification", "Very dense bone"),
+    ("TRABECULAR_BONE", "Trabecular Bone / Fatty Marrow", "Fat-rich cancellous bone"),
+    ("FAT", "Fat (subcutaneous, orbital)", "Fat signal"),
+    ("MUSCLE", "Muscle", "Intermediate intensity muscle"),
+    ("LIVER", "Liver", "Intermediate liver signal"),
+    ("SPLEEN", "Spleen", "Slightly brighter than liver on T2"),
+    ("KIDNEY_CORTEX", "Kidney Cortex", "Outer renal cortex"),
+    ("KIDNEY_MEDULLA", "Kidney Medulla", "Inner renal medulla"),
+    ("CARTILAGE", "Cartilage", "Intermediate-bright cartilage"),
+    ("BLOOD_ACUTE", "Blood (acute, deoxyHb)", "Acute blood signal"),
+    ("WHITE_MATTER", "White Matter", "Brighter than gray on T1"),
+    ("GRAY_MATTER", "Gray Matter", "Brighter than white on T2"),
+    ("CSF_WATER", "CSF / Water / Edema", "Fluid signal"),
+]
+
+
+def get_material_intensity(material_key: str, modality: str) -> float | None:
+    """Return the representative intensity for ``material_key`` in ``modality``."""
+
+    intensities = MATERIAL_INTENSITIES.get(material_key)
+    if not intensities:
+        return None
+    return intensities.get(modality)
+
 PYDICOM_AVAILABLE = False
 Dataset = None
 FileDataset = None
@@ -28,6 +142,14 @@ __all__ = [
     "DEFAULT_DENSITY",
     "MAX_HU_VALUE",
     "MIN_HU_VALUE",
+    "MODALITY_CT",
+    "MODALITY_MRI_T1",
+    "MODALITY_MRI_T2",
+    "MRI_MODALITIES",
+    "IMAGING_MODALITY_ITEMS",
+    "MATERIAL_INTENSITIES",
+    "MATERIAL_ITEMS",
+    "get_material_intensity",
     "PYDICOM_AVAILABLE",
     "Dataset",
     "FileDataset",

--- a/properties.py
+++ b/properties.py
@@ -3,6 +3,46 @@ from __future__ import annotations
 
 import bpy
 
+from .constants import IMAGING_MODALITY_ITEMS, get_material_intensity
+
+
+def apply_material_intensity(obj: bpy.types.Object, modality: str) -> None:
+    """Assign the intensity for ``obj`` based on its material and modality."""
+
+    material_key = getattr(obj, "dicomator_material", "CUSTOM")
+    if material_key == "CUSTOM":
+        return
+
+    value = get_material_intensity(material_key, modality)
+    if value is not None:
+        obj.dicomator_hu = float(value)
+
+
+def update_imaging_modality(self, context: bpy.types.Context) -> None:
+    """Refresh material-derived intensities when the modality changes."""
+
+    if context is None or context.scene is None:
+        return
+
+    for obj in context.scene.objects:
+        if obj.type != 'MESH':
+            continue
+        apply_material_intensity(obj, self.imaging_modality)
+
+
+def update_object_material(self, context: bpy.types.Context) -> None:
+    """Update an object's intensity when its material preset changes."""
+
+    if context is None or context.scene is None:
+        return
+
+    props = getattr(context.scene, "dicomator_props", None)
+    if props is None:
+        return
+
+    modality = getattr(props, "imaging_modality", IMAGING_MODALITY_ITEMS[0][0])
+    apply_material_intensity(self, modality)
+
 
 class DICOMatorProperties(bpy.types.PropertyGroup):
     """Properties exposed in the DICOMator UI."""
@@ -41,6 +81,13 @@ class DICOMatorProperties(bpy.types.PropertyGroup):
             ('FFDL', 'Feet First Decubitus Left', 'Feet First Decubitus Left'),
         ],
         default='HFS',
+    )
+    imaging_modality: bpy.props.EnumProperty(
+        name="Imaging Modality",
+        description="Select the imaging modality used for material presets",
+        items=IMAGING_MODALITY_ITEMS,
+        default=IMAGING_MODALITY_ITEMS[0][0],
+        update=update_imaging_modality,
     )
     export_4d: bpy.props.BoolProperty(
         name="Export 4D (use animated frames)",
@@ -117,6 +164,27 @@ class DICOMatorProperties(bpy.types.PropertyGroup):
         soft_max=500.0,
         step=10,
         precision=1,
+    )
+    enable_bias_field: bpy.props.BoolProperty(
+        name="Add Bias Field Shading",
+        description="Apply low-frequency coil shading variations (MRI)",
+        default=False,
+    )
+    bias_field_strength: bpy.props.FloatProperty(
+        name="Bias Strength",
+        description="Fractional amplitude of the multiplicative bias field",
+        default=0.25,
+        min=0.0,
+        max=1.0,
+        subtype='FACTOR',
+    )
+    bias_field_scale: bpy.props.FloatProperty(
+        name="Bias Scale",
+        description="Relative smoothing window controlling how quickly the bias varies",
+        default=0.3,
+        min=0.05,
+        max=1.0,
+        precision=2,
     )
     enable_partial_volume: bpy.props.BoolProperty(
         name="Add Partial Volume Blur",
@@ -263,4 +331,9 @@ class DICOMatorProperties(bpy.types.PropertyGroup):
     )
 
 
-__all__ = ["DICOMatorProperties"]
+__all__ = [
+    "DICOMatorProperties",
+    "apply_material_intensity",
+    "update_imaging_modality",
+    "update_object_material",
+]


### PR DESCRIPTION
## Summary
- add an MRI bias-field artifact option and hide CT-only effects when an MR modality is selected
- gate artifact application and DICOM export metadata on the chosen modality, including MR Image Storage output and filenames
- document the modality-specific artifact panel behaviour and updated export details in the README

## Testing
- python -m compileall DICOMator

------
https://chatgpt.com/codex/tasks/task_e_68df587424248321a6064e15bc0675fe