### PR TITLE
Fix export directory path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Blender add-on that converts selected mesh objects into DICOM outputs for either
   - Customizable Series Description per export or phase
 - **Export path handling and progress feedback**
   - Accepts Blender-relative paths starting with `//` (resolved relative to the `.blend` file or current working directory)
+  - Defaults to `//DICOM_Export` so a new install starts with a portable export location instead of an OS-specific absolute path
   - Progress bar feedback for voxelization and slice writing
 - **Selection insights**
   - Live estimates of grid dimensions, voxel counts, and approximate memory usage before export
@@ -86,7 +87,7 @@ Dependency note:
      - Configure **Lateral (mm)** and **Axial (mm)** voxel spacing
      - Toggle **Apply Modifiers/Deformations** to evaluate modifiers, armatures, and shape keys during voxelization
      - In DRR mode, set **DRR Resolution Scale** to scale the Blender render resolution used for the projection detector
-     - Choose an **Export Directory** (supports `//` relative paths)
+     - Choose an **Export Directory** (supports `//` relative paths and defaults to `//DICOM_Export`)
      - Toggle **Export 4D** to export multiple frames
        - Use the timeline range or set a custom `Start`/`End`/`Frame Step`
      - Enter a **Series Description** (used directly or extended per phase)
@@ -163,7 +164,7 @@ Notes:
 - **“Set an active scene camera before exporting a DRR”**
   - Assign a camera to the scene (`Scene Properties → Camera`) or make a camera active in the 3D View before DRR export.
 - **“Output directory is not writable”**
-  - Choose a folder with write permissions; for `//` paths, save your `.blend` so the relative path resolves.
+  - Choose a folder with write permissions; blank export paths are rejected, and for `//` paths, save your `.blend` so the relative path resolves.
 - **Artifacts look too strong/weak**
   - Adjust intensity/severity controls or disable individual artifact toggles to isolate effects.
 

--- a/operators.py
+++ b/operators.py
@@ -28,7 +28,7 @@ from .constants import (
 )
 from .dicom_export import export_projection_to_dicom, export_voxel_grid_to_dicom
 from .drr import generate_drr_from_hu_volume
-from .utils import force_ui_redraw, get_float_prop
+from .utils import force_ui_redraw, get_float_prop, resolve_output_directory
 from .voxelization import voxelize_objects_to_hu
 
 
@@ -39,20 +39,6 @@ def _get_int_prop(props, name: str, default: int) -> int:
         return int(getattr(props, name))
     except Exception:
         return int(default)
-
-
-def _resolve_output_directory(output_dir: str) -> str:
-    """Resolve Blender-relative paths into an absolute output directory."""
-
-    resolved_dir = str(output_dir or "")
-    if resolved_dir.startswith('//'):
-        relative_path = resolved_dir[2:].replace('/', os.sep).replace('\\', os.sep)
-        if bpy.data.filepath:
-            blend_dir = os.path.dirname(bpy.data.filepath)
-            resolved_dir = os.path.join(blend_dir, relative_path)
-        else:
-            resolved_dir = os.path.join(os.getcwd(), relative_path)
-    return os.path.abspath(os.path.normpath(resolved_dir))
 
 
 def _apply_configured_artifacts(hu_array, props):
@@ -306,7 +292,7 @@ class MESH_OT_export_dicom(Operator):
             return {'CANCELLED'}
 
         props = context.scene.dicomator_props
-        output_dir = _resolve_output_directory(props.export_directory)
+        output_dir = resolve_output_directory(props.export_directory)
         if not output_dir:
             self.report({'ERROR'}, "Please specify an export directory")
             return {'CANCELLED'}

--- a/panels.py
+++ b/panels.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import math
-import os
 
 import bpy
 from bpy.types import Context, Panel
@@ -10,7 +9,7 @@ from mathutils import Vector
 
 from .constants import MRI_MODALITIES, OUTPUT_MODE_DRR, ensure_pydicom_available, get_pydicom_error
 from .drr import resolve_drr_detector_size
-from .utils import get_float_prop, get_str_prop
+from .utils import get_float_prop, get_str_prop, resolve_output_directory
 
 
 class VIEW3D_PT_dicomator_panel(Panel):
@@ -231,14 +230,8 @@ class VIEW3D_PT_dicomator_export_settings(Panel):
             col.prop(props, "frame_step")
 
         export_dir_val = get_str_prop(props, "export_directory", "")
-        if export_dir_val.startswith('//'):
-            relative_path = export_dir_val[2:].replace('/', os.sep).replace('\\', os.sep)
-            if bpy.data.filepath:
-                blend_dir = os.path.dirname(bpy.data.filepath)
-                resolved_path = os.path.join(blend_dir, relative_path)
-            else:
-                resolved_path = os.path.join(os.getcwd(), relative_path)
-            resolved_path = os.path.abspath(os.path.normpath(resolved_path))
+        resolved_path = resolve_output_directory(export_dir_val)
+        if resolved_path and export_dir_val.strip().startswith('//'):
             box.label(text=f"Resolved: {resolved_path}", icon='FILE_FOLDER')
 
         box.prop(props, "series_description")
@@ -319,15 +312,7 @@ class VIEW3D_PT_dicomator_export_settings(Panel):
                 motion_box.prop(props, "motion_severity")
 
         if ensure_pydicom_available():
-            export_dir = get_str_prop(props, "export_directory", "")
-            if export_dir.startswith('//'):
-                relative_path = export_dir[2:].replace('/', os.sep).replace('\\', os.sep)
-                if bpy.data.filepath:
-                    blend_dir = os.path.dirname(bpy.data.filepath)
-                    export_dir = os.path.join(blend_dir, relative_path)
-                else:
-                    export_dir = os.path.join(os.getcwd(), relative_path)
-                export_dir = os.path.abspath(os.path.normpath(export_dir))
+            export_dir = resolve_output_directory(get_str_prop(props, "export_directory", ""))
 
             if export_dir and export_dir.strip():
                 if context.active_object and context.active_object.type == 'MESH':

--- a/properties.py
+++ b/properties.py
@@ -159,7 +159,7 @@ class DICOMatorProperties(bpy.types.PropertyGroup):
         name="Export Directory",
         description="Directory to save DICOM files",
         subtype='DIR_PATH',
-        default="C:\\Users\\Public\\DICOM_Export",
+        default="//DICOM_Export",
     )
     series_description: bpy.props.StringProperty(
         name="Series Description",

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,8 @@
 """Utility helpers for Blender property access and UI refresh."""
 from __future__ import annotations
 
+import os
+
 import bpy
 
 
@@ -22,6 +24,24 @@ def get_str_prop(props, name: str, default: str) -> str:
         return str(default)
 
 
+def resolve_output_directory(output_dir: str) -> str:
+    """Resolve Blender-relative paths into an absolute export directory."""
+
+    resolved_dir = str(output_dir or "").strip()
+    if not resolved_dir:
+        return ""
+
+    if resolved_dir.startswith('//'):
+        relative_path = resolved_dir[2:].replace('/', os.sep).replace('\\', os.sep)
+        if bpy.data.filepath:
+            blend_dir = os.path.dirname(bpy.data.filepath)
+            resolved_dir = os.path.join(blend_dir, relative_path)
+        else:
+            resolved_dir = os.path.join(os.getcwd(), relative_path)
+
+    return os.path.abspath(os.path.normpath(resolved_dir))
+
+
 def force_ui_redraw() -> None:
     """Trigger a UI redraw so timeline/frame changes are visible to the user."""
     try:
@@ -34,4 +54,9 @@ def force_ui_redraw() -> None:
                     area.tag_redraw()
 
 
-__all__ = ["get_float_prop", "get_str_prop", "force_ui_redraw"]
+__all__ = [
+    "get_float_prop",
+    "get_str_prop",
+    "resolve_output_directory",
+    "force_ui_redraw",
+]


### PR DESCRIPTION
### Motivation
- Prevent silent exports into the process working directory when the export path is blank or whitespace. 
- Make the default export path portable across platforms by avoiding a Windows-only absolute path. 

### Description
- Add `resolve_output_directory()` in `utils.py` to centralize resolution of Blender-style `//` relative paths and preserve truly blank paths as empty. 
- Use `resolve_output_directory()` from the export operator so blank/whitespace `export_directory` values correctly trigger the existing "Please specify an export directory" validation. 
- Reuse the same resolver in the export UI panel so the displayed resolved path and the operator behavior are consistent. 
- Change the default `export_directory` in `properties.py` to the portable Blender-relative `//DICOM_Export` and update `README.md` to document the new default and blank-path validation. 

### Testing
- Checked syntax and bytecode compilation with `python -m py_compile operators.py panels.py properties.py utils.py`, which succeeded. 
- Ran a repository-wide compile check with `python -m compileall .`, which succeeded. 
- Ran `git diff --check` to validate diffs and spacing, which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be433b1358832186d8bbdb717a1e79)