### PR TITLE
Harden artifact parameter validation during export

### DIFF
--- a/artifacts.py
+++ b/artifacts.py
@@ -376,6 +376,8 @@ def add_motion_artifact(
         return hu_array.astype(np.int16, copy=False)
     if blur_size % 2 == 0:
         raise ValueError("blur_size must be an odd integer >= 1")
+    if axis not in (0, 1):
+        raise ValueError("axis must be 0 (x) or 1 (y) for in-plane motion blur")
 
     severity = float(np.clip(severity, 0.0, 1.0))
     generator = _get_generator(rng)

--- a/operators.py
+++ b/operators.py
@@ -77,7 +77,9 @@ def _apply_configured_artifacts(hu_array, props):
     if getattr(props, "enable_ring_artifacts", False) and is_ct:
         ring_intensity = max(0.0, get_float_prop(props, "ring_intensity", 80.0))
         ring_radius = None if getattr(props, "ring_random_radius", False) else get_float_prop(props, "ring_radius", 0.5)
-        thickness = max(0.0, get_float_prop(props, "ring_thickness", 0.02))
+        # ``add_ring_artifacts`` requires strictly positive thickness.
+        # Keep UI-entered zero values from aborting the export pipeline.
+        thickness = max(1e-4, get_float_prop(props, "ring_thickness", 0.02))
         jitter = max(0.0, get_float_prop(props, "ring_jitter", 0.02))
         result = add_ring_artifacts(
             result,


### PR DESCRIPTION
### Motivation
- Avoid runtime export failures caused by invalid artifact parameters that surfaced as cryptic exceptions during long-running exports.

### Description
- Clamp UI-provided `ring_thickness` to a small positive minimum before calling `add_ring_artifacts` to prevent a `ValueError` when thickness is zero (`operators.py`).
- Add explicit axis validation in `add_motion_artifact` so only in-plane axes `0` or `1` are accepted and otherwise raise a clear `ValueError` (`artifacts.py`).
- Changes are limited to `operators.py` and `artifacts.py` and include brief comments explaining the guards.

### Testing
- Ran `python -m compileall .` to validate syntax across the package and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e169418f7083219032793e11ee7ff0)