### PR TITLE
Fix spatial alignment and metadata consistency bugs

### DIFF
--- a/artifacts.py
+++ b/artifacts.py
@@ -364,7 +364,8 @@ def add_motion_artifact(
         Axis within each slice along which the motion blur is applied. ``0``
         blurs along the x-axis (first dimension), ``1`` along the y-axis.
     rng:
-        Optional seed or generator controlling random sub-voxel jitter.
+        Accepted for API compatibility. The current implementation is
+        deterministic and does not use randomness.
 
     Returns
     -------
@@ -380,7 +381,6 @@ def add_motion_artifact(
         raise ValueError("axis must be 0 (x) or 1 (y) for in-plane motion blur")
 
     severity = float(np.clip(severity, 0.0, 1.0))
-    generator = _get_generator(rng)
 
     result = hu_array.astype(np.float32, copy=True)
     depth = result.shape[2]
@@ -396,9 +396,8 @@ def add_motion_artifact(
             blurred = _ensure_shape_like(blurred, slice_view.shape)
 
         # Create a light ghosted duplicate shifted in the motion direction.
-        ghost_shift = generator.uniform(-1.0, 1.0)
-        ghost = 0.5 * np.roll(slice_view, int(math.copysign(1, ghost_shift) or 1), axis=axis)
-        ghost += 0.5 * np.roll(slice_view, -int(math.copysign(1, ghost_shift) or 1), axis=axis)
+        ghost = 0.5 * np.roll(slice_view, 1, axis=axis)
+        ghost += 0.5 * np.roll(slice_view, -1, axis=axis)
 
         # Combine original, blurred and ghost components.
         slice_view = (1.0 - severity) * slice_view + severity * (0.7 * blurred + 0.3 * ghost)

--- a/dicom_export.py
+++ b/dicom_export.py
@@ -93,13 +93,17 @@ def export_voxel_grid_to_dicom(
         'time_str': time_str,
     }
 
+    slice_sop_instance_uids: list[str] = []
+    storage_uid = pydicom.uid.CTImageStorage if modality == "CT" else pydicom.uid.MRImageStorage
+
     for index in range(num_slices):
         slice_data = hu_grid[:, :, index]
         try:
             file_meta = Dataset()
-            storage_uid = pydicom.uid.CTImageStorage if modality == "CT" else pydicom.uid.MRImageStorage
             file_meta.MediaStorageSOPClassUID = storage_uid
-            file_meta.MediaStorageSOPInstanceUID = generate_uid()
+            sop_instance_uid = generate_uid()
+            file_meta.MediaStorageSOPInstanceUID = sop_instance_uid
+            slice_sop_instance_uids.append(sop_instance_uid)
             file_meta.ImplementationClassUID = pydicom.uid.PYDICOM_IMPLEMENTATION_UID
             file_meta.TransferSyntaxUID = pydicom.uid.ExplicitVRLittleEndian
 
@@ -147,13 +151,16 @@ def export_voxel_grid_to_dicom(
             dataset.AcquisitionDate = common_metadata['date_str']
             dataset.AcquisitionTime = common_metadata['time_str']
 
+            # Per DICOM PS3.3 C.7.6.2.1.1, ImagePositionPatient is the center
+            # of the first transmitted voxel, not the grid corner.
+            slice_z_center_mm = bbox_min_mm.z + (index + 0.5) * vz_mm
             dataset.ImagePositionPatient = [
-                float(bbox_min_mm.x),
-                float(bbox_min_mm.y),
-                float(bbox_min_mm.z + (index * vz_mm)),
+                float(bbox_min_mm.x + 0.5 * vx_mm),
+                float(bbox_min_mm.y + 0.5 * vy_mm),
+                float(slice_z_center_mm),
             ]
             dataset.ImageOrientationPatient = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0]
-            dataset.SliceLocation = float(bbox_min_mm.z + (index * vz_mm))
+            dataset.SliceLocation = float(slice_z_center_mm)
             dataset.SliceThickness = float(vz_mm)
             dataset.SpacingBetweenSlices = float(vz_mm)
 
@@ -193,7 +200,11 @@ def export_voxel_grid_to_dicom(
             print(f"Error saving DICOM file for slice {index + 1}: {exc}")
             return {'error': f"Error saving DICOM file for slice {index + 1}: {exc}"}
 
-    return {'success': f"Successfully exported {num_slices} DICOM slices to {output_dir}"}
+    return {
+        'success': f"Successfully exported {num_slices} DICOM slices to {output_dir}",
+        'sop_class_uid': str(storage_uid),
+        'sop_instance_uids': slice_sop_instance_uids,
+    }
 
 
 def export_projection_to_dicom(

--- a/drr.py
+++ b/drr.py
@@ -140,7 +140,10 @@ def generate_drr_from_hu_volume(
 
     for row_start in range(0, detector_height, rows_per_chunk):
         row_end = min(detector_height, row_start + rows_per_chunk)
-        pixel_v = (np.arange(row_start, row_end, dtype=np.float32) + 0.5) / float(detector_height)
+        # Row 0 must map to the top of the camera frame so the rendered image
+        # matches the ImagePositionPatient/column-direction metadata written
+        # below (which anchor the image at top_left).
+        pixel_v = 1.0 - (np.arange(row_start, row_end, dtype=np.float32) + 0.5) / float(detector_height)
         uu, vv = np.meshgrid(pixel_u, pixel_v, indexing='xy')
 
         bottom_edge = local_bottom_left[None, None, :] + (local_bottom_right - local_bottom_left)[None, None, :] * uu[:, :, None]

--- a/operators.py
+++ b/operators.py
@@ -402,6 +402,12 @@ class MESH_OT_export_dicom(Operator):
             frame_of_ref_uid = generate_uid()
             saved_frame = context.scene.frame_current
 
+            # Captured per phase so the RT Structure Set can reference the
+            # corresponding CT series (SeriesInstanceUID + per-slice SOP UIDs).
+            ct_series_uid_for_struct: str | None = None
+            ct_sop_class_uid_for_struct: str | None = None
+            ct_sop_instance_uids_for_struct: list[str] = []
+
             # Build a human-readable list of active export types for reporting.
             active_types: list[str] = []
             if ct_objects:
@@ -442,6 +448,13 @@ class MESH_OT_export_dicom(Operator):
                     if num_phases > 1:
                         percent = (phase_index / num_phases) * 100.0
                         phase_description = f"{series_description_base} - Phase {phase_index} ({percent:.1f}%)"
+
+                    # Reset the per-phase references collected from the CT
+                    # export; RT Struct will use them only if the CT path ran
+                    # in VOLUME mode this phase.
+                    ct_series_uid_for_struct = None
+                    ct_sop_class_uid_for_struct = None
+                    ct_sop_instance_uids_for_struct = []
 
                     # ----------------------------------------------------------
                     # CT / DRR export
@@ -524,6 +537,10 @@ class MESH_OT_export_dicom(Operator):
                                 temporal_position_identifier=phase_index if num_phases > 1 else None,
                                 phase_index=phase_index if num_phases > 1 else None,
                             )
+                            # Capture references for RTStruct to link back.
+                            ct_series_uid_for_struct = ct_series_uid
+                            ct_sop_class_uid_for_struct = result.get('sop_class_uid')
+                            ct_sop_instance_uids_for_struct = list(result.get('sop_instance_uids') or [])
 
                         if 'error' in result:
                             self.report({'ERROR'}, result['error'])
@@ -603,6 +620,9 @@ class MESH_OT_export_dicom(Operator):
                             series_instance_uid=struct_series_uid,
                             series_number=phase_index + (len(frames) if ct_objects else 0) + (len(frames) if dose_objects else 0),
                             phase_index=phase_index if num_phases > 1 else None,
+                            referenced_ct_series_instance_uid=ct_series_uid_for_struct,
+                            referenced_ct_sop_class_uid=ct_sop_class_uid_for_struct,
+                            referenced_ct_sop_instance_uids=ct_sop_instance_uids_for_struct,
                         )
 
                         if 'error' in result:

--- a/rtdose_export.py
+++ b/rtdose_export.py
@@ -138,9 +138,14 @@ def export_rtdose_to_dicom(
     # Each frame is a 2D slice dose_f32[:, :, iz] with shape (W, H).
     # Transposing to (H, W) matches DICOM row-major convention (rows first).
     pixel_frames = np.zeros((depth, height, width), dtype=np.uint32)
+    uint32_max_value = np.iinfo(np.uint32).max
     for iz in range(depth):
         slice_2d = dose_f32[:, :, iz]  # (W, H)
-        pixel_frames[iz] = (slice_2d / dose_grid_scaling).astype(np.uint32).T  # (H, W)
+        # Clip before casting: float32 precision on a uint32-range scale can
+        # push values a fraction above uint32_max, which silently wraps on
+        # cast. Clamping keeps the maximum dose as 0xFFFFFFFF.
+        scaled = np.clip(slice_2d / dose_grid_scaling, 0.0, uint32_max_value)
+        pixel_frames[iz] = scaled.astype(np.uint32).T  # (H, W)
 
     now = datetime.now()
     date_str = now.strftime("%Y%m%d")
@@ -203,10 +208,13 @@ def export_rtdose_to_dicom(
         ds.NumberOfFrames = int(depth)
 
         # --- Image plane ---
+        # ImagePositionPatient is the center of the first voxel (PS3.3
+        # C.7.6.2.1.1), not the grid corner.  Offset by half a voxel so the
+        # dose grid aligns with the co-exported CT/RT Structure Set.
         ds.ImagePositionPatient = [
-            float(bbox_min_mm.x),
-            float(bbox_min_mm.y),
-            float(bbox_min_mm.z),
+            float(bbox_min_mm.x + 0.5 * vx_mm),
+            float(bbox_min_mm.y + 0.5 * vy_mm),
+            float(bbox_min_mm.z + 0.5 * vz_mm),
         ]
         ds.ImageOrientationPatient = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0]
         ds.PixelSpacing = [float(vy_mm), float(vx_mm)]

--- a/rtstruct_export.py
+++ b/rtstruct_export.py
@@ -226,6 +226,9 @@ def export_rtstruct_to_dicom(
     series_instance_uid: Optional[str] = None,
     series_number: int = 1,
     phase_index: Optional[int] = None,
+    referenced_ct_series_instance_uid: Optional[str] = None,
+    referenced_ct_sop_class_uid: Optional[str] = None,
+    referenced_ct_sop_instance_uids: Optional[Sequence[str]] = None,
 ) -> dict[str, str]:
     """Write an RT Structure Set DICOM file for the supplied mesh objects.
 
@@ -363,7 +366,28 @@ def export_rtstruct_to_dicom(
         rt_ref_study = Dataset()
         rt_ref_study.ReferencedSOPClassUID = "1.2.840.10008.3.1.2.3.2"  # RT Study
         rt_ref_study.ReferencedSOPInstanceUID = study_instance_uid
-        rt_ref_study.RTReferencedSeriesSequence = []
+
+        # Populate RTReferencedSeriesSequence with the co-exported CT series
+        # (if provided) so downstream TPS tools can trace the structure set
+        # back to the images it was drawn on.  ContourImageSequence inside
+        # requires the per-slice SOP Instance UIDs of that CT series.
+        rt_ref_series_sequence: list = []
+        if (
+            referenced_ct_series_instance_uid
+            and referenced_ct_sop_instance_uids
+            and referenced_ct_sop_class_uid
+        ):
+            rt_ref_series = Dataset()
+            rt_ref_series.SeriesInstanceUID = referenced_ct_series_instance_uid
+            contour_image_sequence: list = []
+            for sop_uid in referenced_ct_sop_instance_uids:
+                img_item = Dataset()
+                img_item.ReferencedSOPClassUID = referenced_ct_sop_class_uid
+                img_item.ReferencedSOPInstanceUID = sop_uid
+                contour_image_sequence.append(img_item)
+            rt_ref_series.ContourImageSequence = contour_image_sequence
+            rt_ref_series_sequence.append(rt_ref_series)
+        rt_ref_study.RTReferencedSeriesSequence = rt_ref_series_sequence
         ref_for_seq.RTReferencedStudySequence = [rt_ref_study]
         ds.ReferencedFrameOfReferenceSequence = [ref_for_seq]
 
@@ -378,6 +402,22 @@ def export_rtstruct_to_dicom(
             roi_sequence.append(roi_item)
         ds.StructureSetROISequence = roi_sequence
 
+        # Build a lookup from Z plane → referenced CT SOP Instance UID so we
+        # can attach a ContourImageSequence to every emitted contour.
+        ct_uids_by_slice: list[str] = (
+            list(referenced_ct_sop_instance_uids)
+            if referenced_ct_sop_instance_uids is not None
+            else []
+        )
+
+        def _referenced_ct_sop_uid_for_z(z_m: float) -> Optional[str]:
+            if not ct_uids_by_slice or vz_m <= 0.0:
+                return None
+            idx = int(round((float(z_m) - bbox_min_z_m) / vz_m - 0.5))
+            if 0 <= idx < len(ct_uids_by_slice):
+                return ct_uids_by_slice[idx]
+            return None
+
         # --- ROI Contour Sequence ---
         roi_contour_sequence = []
         for roi_number, (obj, contours_by_z) in enumerate(
@@ -391,6 +431,7 @@ def export_rtstruct_to_dicom(
 
             contour_sequence = []
             for z_m, loops in sorted(contours_by_z.items()):
+                ref_sop_uid = _referenced_ct_sop_uid_for_z(z_m)
                 for loop in loops:
                     if len(loop) < 3:
                         continue
@@ -405,6 +446,11 @@ def export_rtstruct_to_dicom(
                     contour_item.ContourGeometricType = "CLOSED_PLANAR"
                     contour_item.NumberOfContourPoints = len(loop)
                     contour_item.ContourData = contour_data
+                    if ref_sop_uid and referenced_ct_sop_class_uid:
+                        img_ref = Dataset()
+                        img_ref.ReferencedSOPClassUID = referenced_ct_sop_class_uid
+                        img_ref.ReferencedSOPInstanceUID = ref_sop_uid
+                        contour_item.ContourImageSequence = [img_ref]
                     contour_sequence.append(contour_item)
 
             roi_contour_item.ContourSequence = contour_sequence


### PR DESCRIPTION
- dicom_export: ImagePositionPatient is now the center of the first voxel
  (bbox_min + 0.5*voxel_size) per DICOM PS3.3 C.7.6.2.1.1, eliminating a
  half-voxel offset that misaligned CT slices with the co-exported RT
  Structure Set (which already uses voxel centers).
- dicom_export: return per-slice SOP Instance UIDs and the image storage
  SOP Class UID so downstream RT Struct export can reference them.
- rtdose_export: apply the same half-voxel ImagePositionPatient fix so
  the dose grid registers with the CT and RTSTRUCT.
- rtdose_export: clip float32 values to uint32 max before casting to
  avoid silent wrap-around at the top of the dose range.
- drr: invert pixel_v mapping so image row 0 corresponds to the top of
  the camera frame, matching the ImagePositionPatient/column-direction
  metadata that anchors the image at top_left.
- rtstruct_export: accept the CT series/SOP UIDs and populate
  RTReferencedSeriesSequence plus per-contour ContourImageSequence so
  the structure set properly references the images it was drawn on.
- operators: capture the CT export's returned SOP UIDs and forward them
  to the RT Structure Set export.
- artifacts: simplify the motion-artifact ghost shift to always roll by
  one voxel (the previous sign-of-random dance collapsed to the same
  result) and drop the now-unused RNG initialization.