### PR TITLE
Handle empty mesh geometry in voxelization and bounds estimation

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -141,6 +141,7 @@ def _mesh_bounds_for_objects(
 
     min_x = min_y = min_z = float('inf')
     max_x = max_y = max_z = float('-inf')
+    found_vertex = False
 
     for obj in objects:
         if apply_modifiers and depsgraph is not None:
@@ -155,6 +156,7 @@ def _mesh_bounds_for_objects(
                     max_y = max(max_y, world_vertex.y)
                     min_z = min(min_z, world_vertex.z)
                     max_z = max(max_z, world_vertex.z)
+                    found_vertex = True
             finally:
                 obj_eval.to_mesh_clear()
         else:
@@ -166,7 +168,10 @@ def _mesh_bounds_for_objects(
                 max_y = max(max_y, world_corner.y)
                 min_z = min(min_z, world_corner.z)
                 max_z = max(max_z, world_corner.z)
+                found_vertex = True
 
+    if not found_vertex:
+        raise ValueError("No valid mesh geometry found while estimating bounds")
     return min_x, max_x, min_y, max_y, min_z, max_z
 
 

--- a/voxelization.py
+++ b/voxelization.py
@@ -21,7 +21,12 @@ VectorLike = Sequence[float]
 VoxelSize = Sequence[float]
 
 
-def _bvh_from_object(obj: Object, depsgraph: Optional[bpy.types.Depsgraph] = None, *, apply_modifiers: bool = False) -> BVHTree:
+def _bvh_from_object(
+    obj: Object,
+    depsgraph: Optional[bpy.types.Depsgraph] = None,
+    *,
+    apply_modifiers: bool = False,
+) -> BVHTree | None:
     """Build a BVH tree in world space for ``obj``."""
     if apply_modifiers and depsgraph is not None:
         obj_eval = obj.evaluated_get(depsgraph)
@@ -35,6 +40,8 @@ def _bvh_from_object(obj: Object, depsgraph: Optional[bpy.types.Depsgraph] = Non
         mesh = obj.data
         verts_world = [obj.matrix_world @ vert.co for vert in mesh.vertices]
         polygons = [list(poly.vertices) for poly in mesh.polygons]
+    if not verts_world or not polygons:
+        return None
     return BVHTree.FromPolygons(verts_world, polygons)
 
 
@@ -204,9 +211,14 @@ def voxelize_objects_to_hu(
     object_data: list[tuple[str, BVHTree, np.int16]] = []
     for obj in sorted_objects:
         bvh = _bvh_from_object(obj, depsgraph=depsgraph, apply_modifiers=apply_modifiers)
+        if bvh is None:
+            print(f"Skipping HU voxelization for '{obj.name}': mesh has no faces.")
+            continue
         hu_value = float(getattr(obj, 'dicomator_hu', DEFAULT_DENSITY))
         hu_value = max(MIN_HU_VALUE, min(MAX_HU_VALUE, hu_value))
         object_data.append((obj.name, bvh, np.int16(hu_value)))
+    if not object_data:
+        raise ValueError("No voxelizable objects provided (all selected meshes had zero faces)")
 
     total_columns = width * height
     processed_columns = 0
@@ -246,6 +258,8 @@ def voxelize_objects_to_hu(
                 print(f"  processed columns: {processed_columns}/{total_columns} ({(processed_columns/total_columns)*100:.1f}%)")
 
     print("Voxelization complete (multi-object HU grid).")
+    if progress_callback:
+        progress_callback(total_columns, total_columns)
     return hu_array, origin, (width, height, depth)
 
 
@@ -339,9 +353,14 @@ def voxelize_objects_to_dose(
     object_data: list[tuple[str, BVHTree, float]] = []
     for obj in sorted_objects:
         bvh = _bvh_from_object(obj, depsgraph=depsgraph, apply_modifiers=apply_modifiers)
+        if bvh is None:
+            print(f"Skipping dose voxelization for '{obj.name}': mesh has no faces.")
+            continue
         # Clamp dose to non-negative values; negative dose has no physical meaning.
         dose_value = max(0.0, float(getattr(obj, "dicomator_dose", 0.0)))
         object_data.append((obj.name, bvh, dose_value))
+    if not object_data:
+        raise ValueError("No voxelizable objects provided (all selected meshes had zero faces)")
 
     total_columns = width * height
     processed_columns = 0
@@ -378,6 +397,8 @@ def voxelize_objects_to_dose(
                 print(f"  processed columns: {processed_columns}/{total_columns} ({(processed_columns/total_columns)*100:.1f}%)")
 
     print("Dose voxelization complete.")
+    if progress_callback:
+        progress_callback(total_columns, total_columns)
     return dose_array, origin, (width, height, depth)
 
 


### PR DESCRIPTION
### Motivation
- Prevent hard failures during export when selected meshes have no vertices/faces (common for placeholder or non-mesh objects) and provide clearer feedback to the user.
- Ensure progress callbacks reliably report completion for small grids that never hit the periodic update interval.
- Fail early with a clear error when bounds estimation finds no valid geometry across frames.

### Description
- Guarded BVH construction in `voxelization.py` by updating `_bvh_from_object` to return `None` when a mesh has no vertices or polygons instead of attempting `BVHTree.FromPolygons` on empty data.
- Updated `voxelize_objects_to_hu` and `voxelize_objects_to_dose` in `voxelization.py` to skip objects whose BVH is `None`, log a short message, and raise `ValueError` when all selected objects are non-voxelizable.
- Ensure the final progress state is reported by calling the provided `progress_callback` with completion values at the end of HU and dose voxelization loops.
- Added a bounds-validation check in `operators.py` (`_mesh_bounds_for_objects`) to raise `ValueError` early if no valid mesh geometry is found while estimating multi-frame bounds.

### Testing
- Ran `python -m compileall DICOMator` from the repository root and confirmed all modules compile successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8d6721148321877f3733d2a08342)