### PR TITLE
Fix review findings: DICOM conformance, MR background, robustness, modal export

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,14 @@ Blender add-on that converts selected mesh objects into DICOM outputs for synthe
 - **Export path handling and progress feedback**
   - Accepts Blender-relative paths starting with `//` (resolved relative to the `.blend` file or current working directory)
   - Defaults to `//DICOM_Export` so a new install starts with a portable export location instead of an OS-specific absolute path
-  - Progress bar feedback for voxelization and slice writing
+  - Exports run as a modal background job: the Blender UI stays responsive, a progress bar tracks voxelization and slice writing, and **ESC cancels** the export at any time
+  - Meshes with non-manifold (non-watertight) geometry trigger a warning before export, since ray-cast voxelization assumes closed surfaces
 - **RT Dose export**
   - Mesh objects tagged as RT Dose are voxelized and written as a single multi-frame DICOM RT Dose file (`RTDoseStorage`)
   - Dose values (Gy) are encoded as uint32 scaled by a `DoseGridScaling` factor computed from the peak dose in the grid
+  - Overlapping dose meshes either **sum** (default, matching how physical dose accumulates) or **overwrite** in alphabetical name order, selectable in the dose settings
   - Configurable `DoseType` (Physical / Effective) and `DoseSummationType` (Plan / Fraction / Beam)
+  - A minimal companion RT Plan file (`RTPlanStorage`) is written and referenced via `ReferencedRTPlanSequence`, as required by the RT Dose IOD for the supported summation types
   - RT Dose, image, DRR, and RT Structure exports share the same Study Instance UID and Frame of Reference UID when enabled together
 - **RT Structure Set export**
   - Mesh objects tagged as RT Structure are sliced at each CT Z-plane using bmesh bisection
@@ -100,7 +103,7 @@ Dependency note:
      - Configure **Lateral (mm)** and **Axial (mm)** voxel spacing
      - Toggle **Apply Modifiers/Deformations** to evaluate modifiers, armatures, and shape keys during voxelization
      - When DRR is enabled, set **DRR Resolution Scale** to scale the Blender render resolution used for the projection detector
-     - When any RT Dose mesh is selected, dose settings appear for **Dose Type** (Physical / Effective) and **Dose Summation Type** (Plan / Fraction / Beam)
+     - When any RT Dose mesh is selected, dose settings appear for **Dose Type** (Physical / Effective), **Dose Summation Type** (Plan / Fraction / Beam), and **Dose Overlap** (Sum / Overwrite)
      - Choose an **Export Directory** (supports `//` relative paths and defaults to `//DICOM_Export`)
      - Toggle **Export 4D** to export multiple frames
        - Use the timeline range or set a custom `Start`/`End`/`Frame Step`
@@ -125,6 +128,8 @@ Notes:
 - **Image Series output**
   - Modality: CT (`CTImageStorage`) or MR (`MRImageStorage`) depending on the selected imaging modality
   - Data type: int16 signed (direct HU/intensity values)
+  - Background voxels are -1000 HU (air) for CT and 0 (signal void) for MR
+  - MR series include MR Image module attributes (scanning sequence, TR/TE, etc.) with plausible spin-echo defaults so files pass IOD validation
   - Window: CT exports default to Center 40 / Width 400; MR exports use Center 128 / Width 256
   - Geometry:
     - `PixelSpacing = [voxel_size_mm_y, voxel_size_mm_x]`
@@ -135,7 +140,8 @@ Notes:
   - Storage class: `RTDoseStorage` (SOP class 1.2.840.10008.5.1.4.1.1.481.2)
   - Data type: uint32 multi-frame image scaled by `DoseGridScaling` (Gy/count); maximum dose maps to the full uint32 range
   - Grid dimensions and spatial coordinates match the CT grid exactly, ensuring voxel-to-voxel correspondence
-  - `DoseType`, `DoseSummationType`, and `DoseUnits = GY` are set from the RT Dose Settings panel
+  - `DoseType`, `DoseSummationType`, and `DoseUnits = GY` are set from the RT Dose Settings panel; `FrameIncrementPointer` references `GridFrameOffsetVector` per the multi-frame module
+  - A minimal companion RT Plan (`RTPlan.dcm` / `Phase_###_RTPlan.dcm`) is written and referenced via `ReferencedRTPlanSequence`
   - Shares `StudyInstanceUID` and `FrameOfReferenceUID` with co-exported image, DRR, and structure outputs
 - **RT Structure Set output**
   - Storage class: `RTStructureSetStorage` (SOP class 1.2.840.10008.5.1.4.1.1.481.3)
@@ -146,6 +152,7 @@ Notes:
 - **DRR output**
   - Storage class: Secondary Capture (`SecondaryCaptureImageStorage`) with `ImageType = DERIVED\\PRIMARY\\DRR`
   - Data type: uint16 monochrome projection image
+  - Single-phase exports use percentile auto-windowing; 4D exports use a fixed physical mapping so intensities stay comparable across phases
   - Geometry:
     - `PixelSpacing` follows the active camera detector plane dimensions divided by detector pixels
     - `ImageOrientationPatient` follows the active camera detector row/column axes

--- a/__init__.py
+++ b/__init__.py
@@ -7,26 +7,26 @@ import sys
 import bpy
 from bpy.props import EnumProperty, FloatProperty, PointerProperty
 
-if "bpy" in locals():
-    # Blender keeps add-on submodules alive across disable/enable cycles.
-    # Reload them before named imports so newly added panel/operator classes
-    # are visible without restarting Blender.
-    for _module_name in (
-        "constants",
-        "utils",
-        "artifacts",
-        "dicom_export",
-        "drr",
-        "rtdose_export",
-        "rtstruct_export",
-        "voxelization",
-        "properties",
-        "operators",
-        "panels",
-    ):
-        _qualified_name = f"{__name__}.{_module_name}"
-        if _qualified_name in sys.modules:
-            importlib.reload(sys.modules[_qualified_name])
+# Blender keeps add-on submodules alive in sys.modules across disable/enable
+# cycles. Reload any that are already present (a no-op on first load) before
+# the named imports below so newly added panel/operator classes are visible
+# without restarting Blender.
+for _module_name in (
+    "constants",
+    "utils",
+    "artifacts",
+    "dicom_export",
+    "drr",
+    "rtdose_export",
+    "rtstruct_export",
+    "voxelization",
+    "properties",
+    "operators",
+    "panels",
+):
+    _qualified_name = f"{__name__}.{_module_name}"
+    if _qualified_name in sys.modules:
+        importlib.reload(sys.modules[_qualified_name])
 
 from .artifacts import (
     add_gaussian_noise,
@@ -56,7 +56,7 @@ from .voxelization import voxelize_mesh, voxelize_objects_to_dose, voxelize_obje
 bl_info = {
     "name": "DICOMator",
     "author": "Michael Douglass",
-    "version": (3, 1, 1),
+    "version": (3, 2, 0),
     "blender": (4, 2, 0),
     "location": "View3D > Sidebar > DICOMator",
     "description": "Converts mesh objects into synthetic CT/MR series or camera-based DRR DICOM images",

--- a/artifacts.py
+++ b/artifacts.py
@@ -324,6 +324,9 @@ def add_ring_artifacts(
     ring_radius:
         Relative radius of the ring (0 = center, 1 = edge). When ``None``, a
         small random cluster of detector-channel rings is generated.
+    thickness:
+        Relative radial thickness of each ring (Gaussian width before the
+        per-ring random variation). Must be strictly positive.
     jitter:
         Standard deviation of a low-amplitude speckle field mixed with the
         rings to avoid perfectly smooth structures.

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,6 +1,6 @@
 schema_version = "1.0.0"
 id = "dicomator"  # use lowercase unique id
-version = "3.1.1"
+version = "3.2.0"
 name = "DICOMator"
 tagline = "Converts mesh objects into synthetic CT/MR series or camera-based DRRs"
 maintainer = "Michael Douglass"
@@ -10,7 +10,8 @@ blender_version_min = "4.2.0"
 license = ["SPDX:MIT"]
 tags = ["3D View", "Medical", "CT", "DICOM"]
 copyright = ["2024 Michael Douglass"]
-platforms = ["windows-x64","macos-arm64"]
+# The only bundled wheel (pydicom) is pure Python, so all desktop platforms work.
+platforms = ["windows-x64", "macos-arm64", "macos-x64", "linux-x64"]
 wheels = [
     "./wheels/pydicom-3.0.1-py3-none-any.whl"
 ]

--- a/constants.py
+++ b/constants.py
@@ -163,6 +163,9 @@ RTSTRUCT_SOP_CLASS = "1.2.840.10008.5.1.4.1.1.481.3"
 #: SOP Class UID for RT Dose (DICOM PS3.4 B.5)
 RTDOSE_SOP_CLASS = "1.2.840.10008.5.1.4.1.1.481.2"
 
+#: SOP Class UID for RT Plan (DICOM PS3.4 B.5)
+RTPLAN_SOP_CLASS = "1.2.840.10008.5.1.4.1.1.481.5"
+
 # ---------------------------------------------------------------------------
 # Per-object DICOM type items (used as EnumProperty items on bpy.types.Object)
 # ---------------------------------------------------------------------------
@@ -230,13 +233,24 @@ def ensure_pydicom_available() -> bool:
     # (e.g. data/urls.json), which fails when the module lives inside a zip.
     # Extract the wheel to a real directory alongside the wheel file so that
     # normal filesystem I/O works correctly.
+    #
+    # Extraction is strictly best-effort: the extension directory may be
+    # read-only (system-wide installs), the archive may be corrupt, or two
+    # Blender instances may race on the same directory. Blender >= 4.2
+    # normally installs manifest-declared wheels itself, so on any failure we
+    # fall through to the plain import below instead of breaking add-on
+    # registration.
     _wheels_dir = Path(__file__).parent / "wheels"
     if _wheels_dir.is_dir():
         for _whl in _wheels_dir.glob("pydicom*.whl"):
             _extract_dir = _whl.parent / (_whl.stem + "_extracted")
-            if not _extract_dir.is_dir():
-                with zipfile.ZipFile(_whl) as _zf:
-                    _zf.extractall(_extract_dir)
+            try:
+                if not _extract_dir.is_dir():
+                    with zipfile.ZipFile(_whl) as _zf:
+                        _zf.extractall(_extract_dir)
+            except Exception:
+                LOGGER.warning("Could not extract bundled wheel %s", _whl, exc_info=True)
+                continue
             _extract_str = str(_extract_dir)
             if _extract_str not in sys.path:
                 sys.path.insert(0, _extract_str)
@@ -290,6 +304,7 @@ __all__ = [
     "get_material_intensity",
     "RTSTRUCT_SOP_CLASS",
     "RTDOSE_SOP_CLASS",
+    "RTPLAN_SOP_CLASS",
     "DICOM_OBJECT_TYPE_ITEMS",
     "ROI_TYPE_ITEMS",
     "DOSE_TYPE_ITEMS",

--- a/dicom_export.py
+++ b/dicom_export.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime
-from typing import Callable, Optional, Sequence
+from typing import Callable, Generator, Optional, Sequence
 
 import numpy as np
 from mathutils import Vector
@@ -17,9 +17,34 @@ from .constants import (
 )
 
 SliceProgressCallback = Optional[Callable[[int, int], None]]
+ExportGenerator = Generator[tuple[int, int], None, dict]
 
 
 def export_voxel_grid_to_dicom(
+    voxel_grid: np.ndarray,
+    voxel_size: Sequence[float] | float,
+    output_dir: str,
+    bbox_min: Vector,
+    *,
+    progress_callback: SliceProgressCallback = None,
+    **kwargs,
+) -> dict[str, str]:
+    """Export ``voxel_grid`` to a folder of DICOM slices.
+
+    Blocking wrapper around :func:`export_voxel_grid_to_dicom_iter`; see that
+    function for the keyword arguments.
+    """
+    generator = export_voxel_grid_to_dicom_iter(voxel_grid, voxel_size, output_dir, bbox_min, **kwargs)
+    while True:
+        try:
+            current, total = next(generator)
+        except StopIteration as stop:
+            return stop.value
+        if progress_callback:
+            progress_callback(current, total)
+
+
+def export_voxel_grid_to_dicom_iter(
     voxel_grid: np.ndarray,
     voxel_size: Sequence[float] | float,
     output_dir: str,
@@ -29,7 +54,6 @@ def export_voxel_grid_to_dicom(
     patient_id: str = "12345678",
     patient_sex: str = "M",
     series_description: str = "CT Series from DICOMator",
-    progress_callback: SliceProgressCallback = None,
     direct_hu: bool = False,
     patient_position: str = "HFS",
     dicom_modality: str = "CT",
@@ -41,8 +65,12 @@ def export_voxel_grid_to_dicom(
     number_of_temporal_positions: Optional[int] = None,
     phase_index: Optional[int] = None,
     temporal_position_index: Optional[int] = None,
-) -> dict[str, str]:
-    """Export ``voxel_grid`` to a folder of DICOM slices."""
+) -> ExportGenerator:
+    """Export ``voxel_grid`` to DICOM slices, yielding per-slice progress.
+
+    Yields ``(slices_written, total_slices)`` after each slice and returns the
+    result dict (``{'success': ...}`` or ``{'error': ...}``).
+    """
     if not shared_constants.ensure_pydicom_available():
         return {'error': 'pydicom not available'}
 
@@ -140,6 +168,17 @@ def export_voxel_grid_to_dicom(
                 dataset.TemporalPositionIdentifier = int(temporal_position_identifier)
 
             dataset.Modality = modality
+            if modality == "MR":
+                # MR Image module (PS3.3 C.8.3.1) Type 1/2 attributes with
+                # plausible spin-echo defaults so files pass IOD validation.
+                dataset.ScanningSequence = 'SE'
+                dataset.SequenceVariant = 'NONE'
+                dataset.ScanOptions = ''
+                dataset.MRAcquisitionType = '3D'
+                dataset.RepetitionTime = '500'
+                dataset.EchoTime = '15'
+                dataset.EchoTrainLength = '1'
+                dataset.MagneticFieldStrength = '1.5'
             dataset.Manufacturer = 'DICOMator'
             dataset.InstitutionName = 'Virtual Hospital'
             dataset.StationName = 'Blender'
@@ -175,8 +214,11 @@ def export_voxel_grid_to_dicom(
             dataset.BitsStored = 16
             dataset.HighBit = 15
             dataset.PixelRepresentation = 1
-            dataset.RescaleIntercept = 0.0
-            dataset.RescaleSlope = 1.0
+            if modality == "CT":
+                # Rescale attributes belong to the CT Image module; the MR
+                # Image IOD does not include them.
+                dataset.RescaleIntercept = 0.0
+                dataset.RescaleSlope = 1.0
             if modality == "MR":
                 dataset.WindowCenter = 128
                 dataset.WindowWidth = 256
@@ -190,12 +232,9 @@ def export_voxel_grid_to_dicom(
             else:
                 filename = os.path.join(output_dir, f"{modality}_Slice_{index + 1:04d}.dcm")
 
-            dataset.is_little_endian = True
-            dataset.is_implicit_VR = False
-            dataset.save_as(filename)
+            dataset.save_as(filename, enforce_file_format=True)
 
-            if progress_callback:
-                progress_callback(index + 1, num_slices)
+            yield index + 1, num_slices
         except Exception as exc:  # pragma: no cover - Blender runtime feedback
             print(f"Error saving DICOM file for slice {index + 1}: {exc}")
             return {'error': f"Error saving DICOM file for slice {index + 1}: {exc}"}
@@ -337,13 +376,15 @@ def export_projection_to_dicom(
         dataset.PixelData = image_2d.tobytes()
 
         output_path = os.path.join(output_dir, filename)
-        dataset.is_little_endian = True
-        dataset.is_implicit_VR = False
-        dataset.save_as(output_path)
+        dataset.save_as(output_path, enforce_file_format=True)
     except Exception as exc:  # pragma: no cover - Blender runtime feedback
         return {'error': f"Error saving DRR DICOM file: {exc}"}
 
     return {'success': f"Successfully exported DRR image to {output_dir}"}
 
 
-__all__ = ["export_projection_to_dicom", "export_voxel_grid_to_dicom"]
+__all__ = [
+    "export_projection_to_dicom",
+    "export_voxel_grid_to_dicom",
+    "export_voxel_grid_to_dicom_iter",
+]

--- a/drr.py
+++ b/drr.py
@@ -2,13 +2,15 @@
 from __future__ import annotations
 
 import math
-from typing import Callable, Optional, Sequence
+from typing import Callable, Generator, Optional, Sequence
 
 import bpy
 import numpy as np
 from mathutils import Vector
 
 ProgressCallback = Optional[Callable[[int, int], None]]
+DRRResult = tuple[np.ndarray, dict[str, object]]
+DRRGenerator = Generator[tuple[int, int], None, DRRResult]
 
 
 def resolve_drr_detector_size(scene: bpy.types.Scene, resolution_scale: float = 1.0) -> tuple[int, int]:
@@ -59,11 +61,19 @@ def _ray_box_intersections(
     return entry, exit_, valid
 
 
-def _normalize_projection(line_integrals: np.ndarray) -> np.ndarray:
-    """Map line integrals into a 16-bit display-ready DRR image."""
+def _normalize_projection(line_integrals: np.ndarray, fixed: bool = False) -> np.ndarray:
+    """Map line integrals into a 16-bit display-ready DRR image.
+
+    When ``fixed`` is True the physical absorption fraction ``1 - exp(-L)``
+    is mapped directly onto the uint16 range without percentile stretching,
+    so intensities stay comparable across 4D phases.
+    """
 
     transmission = np.exp(-line_integrals.astype(np.float32, copy=False))
     radiograph = 1.0 - transmission
+
+    if fixed:
+        return np.round(np.clip(radiograph, 0.0, 1.0) * 65535.0).astype(np.uint16, copy=False)
 
     if not np.any(radiograph > 0.0):
         return np.zeros(radiograph.shape, dtype=np.uint16)
@@ -88,8 +98,41 @@ def generate_drr_from_hu_volume(
     *,
     resolution_scale: float = 1.0,
     progress_callback: ProgressCallback = None,
-) -> tuple[np.ndarray, dict[str, object]]:
-    """Project ``hu_volume`` into a DRR using the active camera geometry."""
+    fixed_normalization: bool = False,
+) -> DRRResult:
+    """Project ``hu_volume`` into a DRR using the active camera geometry.
+
+    Blocking wrapper around :func:`generate_drr_from_hu_volume_iter`.
+    """
+    generator = generate_drr_from_hu_volume_iter(
+        hu_volume,
+        voxel_size,
+        origin,
+        scene,
+        camera_obj,
+        resolution_scale=resolution_scale,
+        fixed_normalization=fixed_normalization,
+    )
+    while True:
+        try:
+            current, total = next(generator)
+        except StopIteration as stop:
+            return stop.value
+        if progress_callback:
+            progress_callback(current, total)
+
+
+def generate_drr_from_hu_volume_iter(
+    hu_volume: np.ndarray,
+    voxel_size: Sequence[float] | float,
+    origin: Vector,
+    scene: bpy.types.Scene,
+    camera_obj: bpy.types.Object,
+    *,
+    resolution_scale: float = 1.0,
+    fixed_normalization: bool = False,
+) -> DRRGenerator:
+    """Generator variant: yields ``(rows_done, total_rows)`` per detector chunk."""
 
     if camera_obj is None or camera_obj.type != 'CAMERA':
         raise ValueError("Scene must have an active camera for DRR export")
@@ -199,10 +242,9 @@ def generate_drr_from_hu_volume(
 
         line_integrals[row_start:row_end, :] = chunk_integrals.reshape(row_end - row_start, detector_width)
 
-        if progress_callback is not None:
-            progress_callback(row_end, detector_height)
+        yield row_end, detector_height
 
-    projection_image = _normalize_projection(line_integrals)
+    projection_image = _normalize_projection(line_integrals, fixed=fixed_normalization)
 
     detector_origin_world = camera_obj.matrix_world @ top_left
     row_direction_world = (camera_obj.matrix_world.to_3x3() @ (top_right - top_left)).normalized()
@@ -231,4 +273,8 @@ def generate_drr_from_hu_volume(
     return projection_image, metadata
 
 
-__all__ = ["generate_drr_from_hu_volume", "resolve_drr_detector_size"]
+__all__ = [
+    "generate_drr_from_hu_volume",
+    "generate_drr_from_hu_volume_iter",
+    "resolve_drr_detector_size",
+]

--- a/operators.py
+++ b/operators.py
@@ -1,10 +1,18 @@
-"""Operator definitions for the DICOMator add-on."""
+"""Operator definitions for the DICOMator add-on.
+
+The export operator runs modally: the heavy pipeline stages (voxelization,
+slice writing, DRR projection, contour extraction) are generators that yield
+progress, and a window-manager timer drains them in small time slices so the
+Blender UI stays responsive and the export can be cancelled with ESC.
+"""
 from __future__ import annotations
 
 import math
 import os
-from typing import Iterable, Sequence
+import time
+from typing import Generator, Iterable, Sequence
 
+import bmesh
 import bpy
 from bpy.types import Operator
 from mathutils import Vector
@@ -19,17 +27,21 @@ from .artifacts import (
     apply_partial_volume_effect,
 )
 from .constants import (
+    AIR_DENSITY,
     MODALITY_CT,
     MRI_MODALITIES,
     ensure_pydicom_available,
     generate_uid,
 )
-from .dicom_export import export_projection_to_dicom, export_voxel_grid_to_dicom
-from .drr import generate_drr_from_hu_volume
+from .dicom_export import export_projection_to_dicom, export_voxel_grid_to_dicom_iter
+from .drr import generate_drr_from_hu_volume_iter
 from .rtdose_export import export_rtdose_to_dicom
-from .rtstruct_export import export_rtstruct_to_dicom
-from .utils import force_ui_redraw, get_float_prop, resolve_output_directory
-from .voxelization import voxelize_objects_to_dose, voxelize_objects_to_hu
+from .rtstruct_export import export_rtstruct_to_dicom_iter
+from .utils import get_float_prop, resolve_output_directory
+from .voxelization import voxelize_objects_to_dose_iter, voxelize_objects_to_hu_iter
+
+#: Wall-clock budget (seconds) spent inside the export job per timer tick.
+_MODAL_TIME_BUDGET_S = 0.1
 
 
 def _get_int_prop(props, name: str, default: int) -> int:
@@ -117,16 +129,22 @@ def _apply_configured_artifacts(hu_array, props):
     return result
 
 
-def _make_progress_callback(context: bpy.types.Context, start: float, end: float):
-    """Map a sub-task's 0..1 progress into the Blender progress bar."""
+def _run_subtask(
+    subtask: Generator[tuple[int, int], None, object],
+    start: float,
+    end: float,
+) -> Generator[float, None, object]:
+    """Drive a ``(current, total)``-yielding generator, re-yielding overall
+    progress mapped into ``[start, end]``; returns the subtask's return value."""
 
     span = max(0.0, float(end) - float(start))
-
-    def callback(current: int, total: int) -> None:
+    while True:
+        try:
+            current, total = next(subtask)
+        except StopIteration as stop:
+            return stop.value
         fraction = min(1.0, max(0.0, float(current) / max(1.0, float(total))))
-        context.window_manager.progress_update(float(start) + span * fraction)
-
-    return callback
+        yield float(start) + span * fraction
 
 
 def _mesh_bounds_for_objects(
@@ -173,23 +191,23 @@ def _mesh_bounds_for_objects(
     return min_x, max_x, min_y, max_y, min_z, max_z
 
 
-def _bounds_across_frames(
+def _bounds_across_frames_iter(
     context: bpy.types.Context,
     objects: Sequence[bpy.types.Object],
     frames: Iterable[int],
     *,
     apply_modifiers: bool,
-) -> tuple[float, float, float, float, float, float]:
-    """Return world-space bounds spanning every requested animation frame."""
+) -> Generator[tuple[int, int], None, tuple[float, float, float, float, float, float]]:
+    """Yield per-frame progress while gathering bounds across animation frames."""
 
+    frames = list(frames)
     saved_frame = context.scene.frame_current
     min_x = min_y = min_z = float('inf')
     max_x = max_y = max_z = float('-inf')
 
     try:
-        for frame in frames:
+        for index, frame in enumerate(frames, start=1):
             context.scene.frame_set(int(frame), subframe=0.0)
-            force_ui_redraw()
             depsgraph = context.evaluated_depsgraph_get()
             frame_bounds = _mesh_bounds_for_objects(
                 objects,
@@ -202,10 +220,35 @@ def _bounds_across_frames(
             max_y = max(max_y, frame_bounds[3])
             min_z = min(min_z, frame_bounds[4])
             max_z = max(max_z, frame_bounds[5])
+            yield index, len(frames)
     finally:
         context.scene.frame_set(saved_frame, subframe=0.0)
 
     return min_x, max_x, min_y, max_y, min_z, max_z
+
+
+def _non_manifold_names_iter(
+    objects: Sequence[bpy.types.Object],
+) -> Generator[tuple[int, int], None, list[str]]:
+    """Return names of objects whose base mesh has non-manifold edges.
+
+    Ray-cast voxelization assumes watertight surfaces; non-manifold meshes can
+    produce incorrectly filled columns. The check runs on the base mesh (a
+    modifier stack may change manifoldness either way), so it is a heuristic
+    warning rather than a guarantee.
+    """
+
+    names: list[str] = []
+    for index, obj in enumerate(objects, start=1):
+        bm = bmesh.new()
+        try:
+            bm.from_mesh(obj.data)
+            if any(not edge.is_manifold for edge in bm.edges):
+                names.append(obj.name)
+        finally:
+            bm.free()
+        yield index, len(objects)
+    return names
 
 
 def _pad_bounds(
@@ -266,21 +309,31 @@ def _series_description(base_description: str) -> str:
 
 
 class MESH_OT_export_dicom(Operator):
-    """Export selected meshes to enabled DICOM outputs."""
+    """Export selected meshes to enabled DICOM outputs (ESC cancels)."""
 
     bl_idname = "mesh.export_dicom"
     bl_label = "Export to DICOM"
-    bl_options = {'REGISTER', 'UNDO'}
+    bl_options = {'REGISTER'}
+
+    _timer = None
+    _job = None
+    # Class-level flag: only one modal export may run at a time.
+    _running = False
 
     @classmethod
     def poll(cls, context: bpy.types.Context) -> bool:  # pragma: no cover - Blender UI code
         return (
-            context.active_object is not None
+            not cls._running
+            and context.active_object is not None
             and context.active_object.type == 'MESH'
             and context.active_object.mode == 'OBJECT'
         )
 
     def execute(self, context: bpy.types.Context):  # pragma: no cover - Blender runtime
+        if MESH_OT_export_dicom._running:
+            self.report({'ERROR'}, "A DICOM export is already running")
+            return {'CANCELLED'}
+
         if not ensure_pydicom_available():
             self.report({'ERROR'}, "pydicom library not available")
             return {'CANCELLED'}
@@ -362,13 +415,7 @@ class MESH_OT_export_dicom(Operator):
             self.report({'ERROR'}, "Voxel spacing must be greater than zero")
             return {'CANCELLED'}
 
-        vx_m = float(lateral_mm) * 0.001
-        vy_m = float(lateral_mm) * 0.001
-        vz_m = float(axial_mm) * 0.001
-        voxel_size_m = (vx_m, vy_m, vz_m)
-
         modality_key = getattr(props, "imaging_modality", MODALITY_CT)
-        dicom_modality = "MR" if modality_key in MRI_MODALITIES else "CT"
         if export_drr and modality_key in MRI_MODALITIES:
             self.report({'WARNING'}, "DRR uses current intensities as attenuation. CT modality presets are recommended.")
 
@@ -378,131 +425,232 @@ class MESH_OT_export_dicom(Operator):
             self.report({'ERROR'}, str(exc))
             return {'CANCELLED'}
 
-        apply_modifiers = bool(getattr(props, "apply_modifiers", True))
+        config = {
+            'ct_objects': ct_objects,
+            'dose_objects': dose_objects,
+            'struct_objects': struct_objects,
+            'export_objects': export_objects,
+            'export_image_series': export_image_series,
+            'export_drr': export_drr,
+            'export_rtdose': export_rtdose,
+            'export_rtstruct': export_rtstruct,
+            'camera_obj': camera_obj,
+            'output_dir': output_dir,
+            'lateral_mm': float(lateral_mm),
+            'axial_mm': float(axial_mm),
+            'voxel_size_m': (float(lateral_mm) * 0.001, float(lateral_mm) * 0.001, float(axial_mm) * 0.001),
+            'modality_key': modality_key,
+            'dicom_modality': "MR" if modality_key in MRI_MODALITIES else "CT",
+            'frames': frames,
+            'apply_modifiers': bool(getattr(props, "apply_modifiers", True)),
+        }
+
+        self._job = self._export_job(context, config)
+        window_manager = context.window_manager
+        window_manager.progress_begin(0, 1)
+        window_manager.status_text_set("DICOMator: exporting... (ESC to cancel)")
+        self._timer = window_manager.event_timer_add(0.02, window=context.window)
+        window_manager.modal_handler_add(self)
+        MESH_OT_export_dicom._running = True
+        return {'RUNNING_MODAL'}
+
+    def modal(self, context: bpy.types.Context, event: bpy.types.Event):  # pragma: no cover - Blender runtime
+        if event.type == 'ESC':
+            self._finish(context)
+            self.report({'WARNING'}, "DICOM export cancelled")
+            return {'CANCELLED'}
+        if event.type != 'TIMER':
+            return {'PASS_THROUGH'}
+
+        deadline = time.monotonic() + _MODAL_TIME_BUDGET_S
+        progress = None
+        try:
+            while time.monotonic() < deadline:
+                progress = next(self._job)
+        except StopIteration as stop:
+            self._finish(context)
+            outcome = stop.value or {}
+            if 'error' in outcome:
+                self.report({'ERROR'}, outcome['error'])
+                return {'CANCELLED'}
+            self.report({'INFO'}, outcome.get('success', "DICOM export complete"))
+            return {'FINISHED'}
+        except Exception as exc:
+            self._finish(context)
+            self.report({'ERROR'}, f"Export failed: {exc}")
+            return {'CANCELLED'}
+
+        if progress is not None:
+            context.window_manager.progress_update(float(progress))
+        return {'RUNNING_MODAL'}
+
+    def _finish(self, context: bpy.types.Context) -> None:  # pragma: no cover - Blender runtime
+        MESH_OT_export_dicom._running = False
+        window_manager = context.window_manager
+        if self._timer is not None:
+            window_manager.event_timer_remove(self._timer)
+            self._timer = None
+        if self._job is not None:
+            # Closing the generator runs its finally blocks (frame restore).
+            self._job.close()
+            self._job = None
+        window_manager.status_text_set(None)
+        window_manager.progress_end()
+
+    def _export_job(self, context: bpy.types.Context, config: dict) -> Generator[float, None, dict[str, str]]:
+        """Generator that performs the full export, yielding 0..1 progress."""
+
+        props = context.scene.dicomator_props
+        frames: list[int] = config['frames']
+        num_phases = len(frames)
+        voxel_size_m: tuple[float, float, float] = config['voxel_size_m']
+        apply_modifiers: bool = config['apply_modifiers']
+        output_dir: str = config['output_dir']
+        dicom_modality: str = config['dicom_modality']
+        export_image_series: bool = config['export_image_series']
+        export_drr: bool = config['export_drr']
+        export_rtdose: bool = config['export_rtdose']
+        export_rtstruct: bool = config['export_rtstruct']
+        ct_objects = config['ct_objects']
+        dose_objects = config['dose_objects']
+        struct_objects = config['struct_objects']
         padding_voxels = 1
 
-        try:
-            # ------------------------------------------------------------------
-            # Compute a UNIFIED bounding box across enabled export objects
-            # (CT + RTDOSE + RTSTRUCT as requested) so exported files share the
-            # same coordinate space and FrameOfReferenceUID is meaningful.
-            # ------------------------------------------------------------------
-            bounds = _bounds_across_frames(
+        # MR represents air as signal void (0), not as -1000 HU.
+        background_value = 0.0 if dicom_modality == "MR" else AIR_DENSITY
+
+        non_manifold = yield from _run_subtask(
+            _non_manifold_names_iter(config['export_objects']), 0.0, 0.01
+        )
+        if non_manifold:
+            shown = ", ".join(non_manifold[:5])
+            suffix = "..." if len(non_manifold) > 5 else ""
+            self.report(
+                {'WARNING'},
+                f"Non-manifold meshes may voxelize/contour incorrectly: {shown}{suffix}",
+            )
+
+        # ------------------------------------------------------------------
+        # Compute a UNIFIED bounding box across enabled export objects
+        # (CT + RTDOSE + RTSTRUCT as requested) so exported files share the
+        # same coordinate space and FrameOfReferenceUID is meaningful.
+        # ------------------------------------------------------------------
+        bounds = yield from _run_subtask(
+            _bounds_across_frames_iter(
                 context,
-                export_objects,
+                config['export_objects'],
                 frames,
                 apply_modifiers=apply_modifiers,
-            )
-            padded_bounds = _pad_bounds(bounds, voxel_size_m, padding_voxels)
-            estimated_width, estimated_height, estimated_depth = _estimate_grid_dimensions(padded_bounds, voxel_size_m)
+            ),
+            0.01,
+            0.03,
+        )
+        padded_bounds = _pad_bounds(bounds, voxel_size_m, padding_voxels)
+        estimated_width, estimated_height, estimated_depth = _estimate_grid_dimensions(padded_bounds, voxel_size_m)
 
-            total_estimated_voxels = estimated_width * estimated_height * estimated_depth
-            if (
-                estimated_width > 2000
-                or estimated_height > 2000
-                or estimated_depth > 2000
-                or total_estimated_voxels > 100_000_000
-            ):
-                self.report(
-                    {'WARNING'},
-                    (
-                        "Voxel grid very large: "
-                        f"{estimated_width}x{estimated_height}x{estimated_depth} "
-                        f"({total_estimated_voxels:,} voxels). "
-                        f"Selection size: {(bounds[1] - bounds[0]):.3f}x{(bounds[3] - bounds[2]):.3f}x{(bounds[5] - bounds[4]):.3f}m. "
-                        "Continuing anyway. This may be slow or run out of memory."
-                    ),
-                )
-
-            num_phases = len(frames)
-            series_description_base = _series_description(props.series_description)
-
-            # Generate study-level UIDs once so enabled outputs belong to one
-            # study and frame of reference.
-            study_uid = generate_uid()
-            frame_of_ref_uid = generate_uid()
-            saved_frame = context.scene.frame_current
-
-            # Captured per phase so the RT Structure Set can reference the
-            # corresponding CT series (SeriesInstanceUID + per-slice SOP UIDs).
-            ct_series_uid_for_struct: str | None = None
-            ct_sop_class_uid_for_struct: str | None = None
-            ct_sop_instance_uids_for_struct: list[str] = []
-
-            # Build a human-readable list of active export types for reporting.
-            active_types: list[str] = []
-            if export_image_series:
-                active_types.append(dicom_modality)
-            if export_drr:
-                active_types.append("DRR")
-            if export_rtdose:
-                active_types.append("RT Dose")
-            if export_rtstruct:
-                active_types.append("RT Structure")
-            types_label = " + ".join(active_types)
-
+        total_estimated_voxels = estimated_width * estimated_height * estimated_depth
+        if (
+            estimated_width > 2000
+            or estimated_height > 2000
+            or estimated_depth > 2000
+            or total_estimated_voxels > 100_000_000
+        ):
             self.report(
-                {'INFO'},
+                {'WARNING'},
                 (
-                    f"Exporting {num_phases} phase(s) [{types_label}] "
-                    f"lateral {lateral_mm}mm / axial {axial_mm}mm. "
-                    f"Grid: {estimated_width}x{estimated_height}x{estimated_depth}. "
-                    f"Shared StudyUID: {study_uid[:12]}... ForUID: {frame_of_ref_uid[:12]}..."
+                    "Voxel grid very large: "
+                    f"{estimated_width}x{estimated_height}x{estimated_depth} "
+                    f"({total_estimated_voxels:,} voxels). "
+                    f"Selection size: {(bounds[1] - bounds[0]):.3f}x{(bounds[3] - bounds[2]):.3f}x{(bounds[5] - bounds[4]):.3f}m. "
+                    "Continuing anyway. This may be slow or run out of memory."
                 ),
             )
 
-            context.window_manager.progress_begin(0, 1)
+        series_description_base = _series_description(props.series_description)
 
-            try:
-                for phase_index, frame in enumerate(frames, start=1):
-                    phase_start = float(phase_index - 1) / float(num_phases)
-                    phase_end = float(phase_index) / float(num_phases)
+        # Generate study-level UIDs once so enabled outputs belong to one
+        # study and frame of reference.
+        study_uid = generate_uid()
+        frame_of_ref_uid = generate_uid()
+        saved_frame = context.scene.frame_current
 
-                    # Sub-divide the phase span across active export types.
-                    num_active = len(active_types)
-                    type_span = (phase_end - phase_start) / max(1, num_active)
-                    slot = 0
+        # Build a human-readable list of active export types for reporting.
+        active_types: list[str] = []
+        if export_image_series:
+            active_types.append(dicom_modality)
+        if export_drr:
+            active_types.append("DRR")
+        if export_rtdose:
+            active_types.append("RT Dose")
+        if export_rtstruct:
+            active_types.append("RT Structure")
+        types_label = " + ".join(active_types)
 
-                    context.scene.frame_set(frame, subframe=0.0)
-                    force_ui_redraw()
-                    depsgraph = context.evaluated_depsgraph_get()
+        self.report(
+            {'INFO'},
+            (
+                f"Exporting {num_phases} phase(s) [{types_label}] "
+                f"lateral {config['lateral_mm']}mm / axial {config['axial_mm']}mm. "
+                f"Grid: {estimated_width}x{estimated_height}x{estimated_depth}. "
+                f"Shared StudyUID: {study_uid[:12]}... ForUID: {frame_of_ref_uid[:12]}..."
+            ),
+        )
 
-                    phase_description = series_description_base
-                    if num_phases > 1:
-                        percent = (phase_index / num_phases) * 100.0
-                        phase_description = f"{series_description_base} - Phase {phase_index} ({percent:.1f}%)"
+        work_start = 0.03
 
-                    # Reset the per-phase references collected from image
-                    # export; RT Struct uses them when an image series is
-                    # exported in the same phase.
-                    ct_series_uid_for_struct = None
-                    ct_sop_class_uid_for_struct = None
-                    ct_sop_instance_uids_for_struct = []
+        try:
+            for phase_index, frame in enumerate(frames, start=1):
+                phase_start = work_start + (1.0 - work_start) * (phase_index - 1) / num_phases
+                phase_end = work_start + (1.0 - work_start) * phase_index / num_phases
 
-                    # ----------------------------------------------------------
-                    # Image Series / DRR export from image-type meshes
-                    # ----------------------------------------------------------
-                    if ct_objects and (export_image_series or export_drr):
-                        t_start = phase_start + slot * type_span
-                        voxel_progress = _make_progress_callback(context, t_start, t_start + type_span * 0.45)
+                # Sub-divide the phase span across active export types.
+                num_active = len(active_types)
+                type_span = (phase_end - phase_start) / max(1, num_active)
+                slot = 0
 
-                        hu_array, origin, _dimensions = voxelize_objects_to_hu(
+                context.scene.frame_set(frame, subframe=0.0)
+                depsgraph = context.evaluated_depsgraph_get()
+                yield phase_start
+
+                phase_description = series_description_base
+                if num_phases > 1:
+                    # Label phases with their position in the respiratory/
+                    # acquisition cycle starting at 0% (4DCT convention).
+                    percent = ((phase_index - 1) / num_phases) * 100.0
+                    phase_description = f"{series_description_base} - Phase {phase_index} ({percent:.1f}%)"
+
+                # References collected from image export; RT Struct uses them
+                # when an image series is exported in the same phase.
+                ct_series_uid_for_struct: str | None = None
+                ct_sop_class_uid_for_struct: str | None = None
+                ct_sop_instance_uids_for_struct: list[str] = []
+
+                # ----------------------------------------------------------
+                # Image Series / DRR export from image-type meshes
+                # ----------------------------------------------------------
+                if ct_objects and (export_image_series or export_drr):
+                    t_start = phase_start + slot * type_span
+                    hu_array, origin, _dimensions = yield from _run_subtask(
+                        voxelize_objects_to_hu_iter(
                             ct_objects,
                             voxel_size=voxel_size_m,
                             padding=0,
-                            progress_callback=voxel_progress,
                             bbox_override=padded_bounds,
                             apply_modifiers=apply_modifiers,
                             depsgraph=depsgraph,
-                        )
+                            background_value=background_value,
+                        ),
+                        t_start,
+                        t_start + type_span * 0.45,
+                    )
 
-                        if export_image_series:
-                            write_start = phase_start + slot * type_span
-                            write_progress = _make_progress_callback(context, write_start + type_span * 0.45, write_start + type_span)
-                            slot += 1
-                            image_series_uid = generate_uid()
-                            hu_array_to_export = _apply_configured_artifacts(hu_array, props)
-                            result = export_voxel_grid_to_dicom(
+                    if export_image_series:
+                        write_start = phase_start + slot * type_span
+                        slot += 1
+                        image_series_uid = generate_uid()
+                        hu_array_to_export = _apply_configured_artifacts(hu_array, props)
+                        result = yield from _run_subtask(
+                            export_voxel_grid_to_dicom_iter(
                                 hu_array_to_export,
                                 voxel_size_m,
                                 output_dir,
@@ -511,7 +659,6 @@ class MESH_OT_export_dicom(Operator):
                                 patient_id=props.patient_id,
                                 patient_sex=props.patient_sex,
                                 series_description=phase_description,
-                                progress_callback=write_progress,
                                 direct_hu=True,
                                 patient_position=props.patient_position,
                                 dicom_modality=dicom_modality,
@@ -523,121 +670,127 @@ class MESH_OT_export_dicom(Operator):
                                 temporal_position_index=phase_index if num_phases > 1 else None,
                                 temporal_position_identifier=phase_index if num_phases > 1 else None,
                                 phase_index=phase_index if num_phases > 1 else None,
-                            )
-                            if 'error' in result:
-                                self.report({'ERROR'}, result['error'])
-                                return {'CANCELLED'}
+                            ),
+                            write_start + type_span * 0.45,
+                            write_start + type_span,
+                        )
+                        if 'error' in result:
+                            return result
 
-                            # Capture references for RTStruct to link back.
-                            ct_series_uid_for_struct = image_series_uid
-                            ct_sop_class_uid_for_struct = result.get('sop_class_uid')
-                            ct_sop_instance_uids_for_struct = list(result.get('sop_instance_uids') or [])
+                        # Capture references for RTStruct to link back.
+                        ct_series_uid_for_struct = image_series_uid
+                        ct_sop_class_uid_for_struct = result.get('sop_class_uid')
+                        ct_sop_instance_uids_for_struct = list(result.get('sop_instance_uids') or [])
 
-                        if export_drr:
-                            write_start = phase_start + slot * type_span
-                            progress_start = write_start if export_image_series else write_start + type_span * 0.45
-                            write_progress = _make_progress_callback(context, progress_start, write_start + type_span)
-                            slot += 1
-                            drr_series_uid = generate_uid()
-                            projection_image, projection_metadata = generate_drr_from_hu_volume(
+                    if export_drr:
+                        write_start = phase_start + slot * type_span
+                        progress_start = write_start if export_image_series else write_start + type_span * 0.45
+                        slot += 1
+                        drr_series_uid = generate_uid()
+                        projection_image, projection_metadata = yield from _run_subtask(
+                            generate_drr_from_hu_volume_iter(
                                 hu_array,
                                 voxel_size_m,
                                 origin,
                                 context.scene,
-                                camera_obj,
+                                config['camera_obj'],
                                 resolution_scale=get_float_prop(props, "drr_resolution_scale", 1.0),
-                                progress_callback=write_progress,
-                            )
-                            filename = (
-                                f"Phase_{phase_index:03d}_DRR.dcm"
-                                if num_phases > 1 else
-                                "DRR_Image_0001.dcm"
-                            )
-                            drr_description = phase_description
-                            if "DRR" not in drr_description.upper():
-                                drr_description = f"{drr_description} - DRR"
-                            result = export_projection_to_dicom(
-                                projection_image,
-                                output_dir,
-                                filename=filename,
-                                patient_name=props.patient_name,
-                                patient_id=props.patient_id,
-                                patient_sex=props.patient_sex,
-                                patient_position=props.patient_position,
-                                series_description=drr_description,
-                                pixel_spacing_mm=projection_metadata.get("pixel_spacing_mm"),
-                                image_position_patient=projection_metadata.get("image_position_patient"),
-                                image_orientation_patient=projection_metadata.get("image_orientation_patient"),
-                                study_instance_uid=study_uid,
-                                frame_of_reference_uid=frame_of_ref_uid,
-                                series_instance_uid=drr_series_uid,
-                                series_number=phase_index + (len(frames) if export_image_series else 0),
-                                instance_number=1,
-                                number_of_temporal_positions=num_phases if num_phases > 1 else None,
-                                temporal_position_index=phase_index if num_phases > 1 else None,
-                                temporal_position_identifier=phase_index if num_phases > 1 else None,
-                            )
-                            if 'error' in result:
-                                self.report({'ERROR'}, result['error'])
-                                return {'CANCELLED'}
-
-                    # ----------------------------------------------------------
-                    # RT Dose export
-                    # ----------------------------------------------------------
-                    if export_rtdose and dose_objects:
-                        t_start = phase_start + slot * type_span
-                        dose_voxel_progress = _make_progress_callback(context, t_start, t_start + type_span * 0.55)
-                        slot += 1
-
-                        dose_array, dose_origin, _dose_dims = voxelize_objects_to_dose(
-                            dose_objects,
-                            voxel_size=voxel_size_m,
-                            padding=0,
-                            progress_callback=dose_voxel_progress,
-                            bbox_override=padded_bounds,
-                            apply_modifiers=apply_modifiers,
-                            depsgraph=depsgraph,
+                                # Percentile auto-windowing varies per image;
+                                # use the fixed physical mapping for 4D so
+                                # intensities are comparable across phases.
+                                fixed_normalization=num_phases > 1,
+                            ),
+                            progress_start,
+                            write_start + type_span,
                         )
-
-                        dose_series_uid = generate_uid()
-                        dose_type = getattr(props, "dose_type", "PHYSICAL")
-                        dose_summation_type = getattr(props, "dose_summation_type", "PLAN")
-
-                        result = export_rtdose_to_dicom(
-                            dose_array,
-                            voxel_size_m,
-                            dose_origin,
+                        filename = (
+                            f"Phase_{phase_index:03d}_DRR.dcm"
+                            if num_phases > 1 else
+                            "DRR_Image_0001.dcm"
+                        )
+                        drr_description = phase_description
+                        if "DRR" not in drr_description.upper():
+                            drr_description = f"{drr_description} - DRR"
+                        result = export_projection_to_dicom(
+                            projection_image,
                             output_dir,
+                            filename=filename,
                             patient_name=props.patient_name,
                             patient_id=props.patient_id,
                             patient_sex=props.patient_sex,
                             patient_position=props.patient_position,
-                            series_description=f"{phase_description} - RT Dose",
-                            dose_type=dose_type,
-                            dose_summation_type=dose_summation_type,
+                            series_description=drr_description,
+                            pixel_spacing_mm=projection_metadata.get("pixel_spacing_mm"),
+                            image_position_patient=projection_metadata.get("image_position_patient"),
+                            image_orientation_patient=projection_metadata.get("image_orientation_patient"),
                             study_instance_uid=study_uid,
                             frame_of_reference_uid=frame_of_ref_uid,
-                            series_instance_uid=dose_series_uid,
-                            series_number=phase_index + len(frames) * (int(export_image_series) + int(export_drr)),
-                            phase_index=phase_index if num_phases > 1 else None,
+                            series_instance_uid=drr_series_uid,
+                            series_number=phase_index + (len(frames) if export_image_series else 0),
+                            instance_number=1,
+                            number_of_temporal_positions=num_phases if num_phases > 1 else None,
+                            temporal_position_index=phase_index if num_phases > 1 else None,
+                            temporal_position_identifier=phase_index if num_phases > 1 else None,
                         )
-
                         if 'error' in result:
-                            self.report({'ERROR'}, result['error'])
-                            return {'CANCELLED'}
+                            return result
 
-                    # ----------------------------------------------------------
-                    # RT Structure Set export
-                    # ----------------------------------------------------------
-                    if export_rtstruct and struct_objects:
-                        t_start = phase_start + slot * type_span
-                        slot += 1
+                # ----------------------------------------------------------
+                # RT Dose export
+                # ----------------------------------------------------------
+                if export_rtdose and dose_objects:
+                    t_start = phase_start + slot * type_span
+                    slot += 1
 
-                        struct_series_uid = generate_uid()
-                        # bbox_min for RTSTRUCT uses the padded grid origin:
-                        # padded_bounds = (min_x, max_x, min_y, max_y, min_z, max_z)
-                        struct_bbox_min = Vector((padded_bounds[0], padded_bounds[2], padded_bounds[4]))
-                        result = export_rtstruct_to_dicom(
+                    dose_array, dose_origin, _dose_dims = yield from _run_subtask(
+                        voxelize_objects_to_dose_iter(
+                            dose_objects,
+                            voxel_size=voxel_size_m,
+                            padding=0,
+                            bbox_override=padded_bounds,
+                            apply_modifiers=apply_modifiers,
+                            depsgraph=depsgraph,
+                            accumulate=getattr(props, "dose_accumulation", "SUM") == "SUM",
+                        ),
+                        t_start,
+                        t_start + type_span * 0.9,
+                    )
+
+                    dose_series_uid = generate_uid()
+                    result = export_rtdose_to_dicom(
+                        dose_array,
+                        voxel_size_m,
+                        dose_origin,
+                        output_dir,
+                        patient_name=props.patient_name,
+                        patient_id=props.patient_id,
+                        patient_sex=props.patient_sex,
+                        patient_position=props.patient_position,
+                        series_description=f"{phase_description} - RT Dose",
+                        dose_type=getattr(props, "dose_type", "PHYSICAL"),
+                        dose_summation_type=getattr(props, "dose_summation_type", "PLAN"),
+                        study_instance_uid=study_uid,
+                        frame_of_reference_uid=frame_of_ref_uid,
+                        series_instance_uid=dose_series_uid,
+                        series_number=phase_index + len(frames) * (int(export_image_series) + int(export_drr)),
+                        phase_index=phase_index if num_phases > 1 else None,
+                    )
+                    if 'error' in result:
+                        return result
+
+                # ----------------------------------------------------------
+                # RT Structure Set export
+                # ----------------------------------------------------------
+                if export_rtstruct and struct_objects:
+                    t_start = phase_start + slot * type_span
+                    slot += 1
+
+                    struct_series_uid = generate_uid()
+                    # bbox_min for RTSTRUCT uses the padded grid origin:
+                    # padded_bounds = (min_x, max_x, min_y, max_y, min_z, max_z)
+                    struct_bbox_min = Vector((padded_bounds[0], padded_bounds[2], padded_bounds[4]))
+                    result = yield from _run_subtask(
+                        export_rtstruct_to_dicom_iter(
                             struct_objects,
                             bbox_min=struct_bbox_min,
                             voxel_size=voxel_size_m,
@@ -660,25 +813,18 @@ class MESH_OT_export_dicom(Operator):
                             referenced_ct_series_instance_uid=ct_series_uid_for_struct,
                             referenced_ct_sop_class_uid=ct_sop_class_uid_for_struct,
                             referenced_ct_sop_instance_uids=ct_sop_instance_uids_for_struct,
-                        )
+                        ),
+                        t_start,
+                        t_start + type_span,
+                    )
+                    if 'error' in result:
+                        return result
 
-                        if 'error' in result:
-                            self.report({'ERROR'}, result['error'])
-                            return {'CANCELLED'}
+                yield phase_end
+        finally:
+            context.scene.frame_set(saved_frame, subframe=0.0)
 
-            finally:
-                context.scene.frame_set(saved_frame, subframe=0.0)
-                context.window_manager.progress_end()
-
-            self.report({'INFO'}, f"Successfully exported {num_phases} phase(s) [{types_label}] to {output_dir}")
-            return {'FINISHED'}
-        except Exception as exc:
-            try:
-                context.window_manager.progress_end()
-            except Exception:
-                pass
-            self.report({'ERROR'}, f"Export failed: {exc}")
-            return {'CANCELLED'}
+        return {'success': f"Successfully exported {num_phases} phase(s) [{types_label}] to {output_dir}"}
 
 
 __all__ = ["MESH_OT_export_dicom"]

--- a/panels.py
+++ b/panels.py
@@ -202,8 +202,28 @@ class VIEW3D_PT_dicomator_selection_info(Panel):
             col.label(text=f"Est. Grid: {est_width} x {est_height} x {est_depth}")
             col.label(text=f"Total Voxels: {total_voxels:,}")
 
-            memory_mb = (total_voxels * 2) / (1024 * 1024)
-            col.label(text=f"Est. Memory: {memory_mb:.1f} MB")
+            # int16 grid is 2 bytes/voxel; the artifact pipeline works on
+            # float32 copies (~12 bytes/voxel peak) and the DRR keeps a
+            # float32 attenuation volume (4 bytes/voxel).
+            bytes_per_voxel = 2
+            artifacts_enabled = any(
+                getattr(props, flag, False)
+                for flag in (
+                    "enable_noise",
+                    "enable_partial_volume",
+                    "enable_metal_artifacts",
+                    "enable_ring_artifacts",
+                    "enable_motion_artifact",
+                    "enable_poisson_noise",
+                    "enable_bias_field",
+                )
+            )
+            if artifacts_enabled:
+                bytes_per_voxel += 12
+            if getattr(props, "export_drr", False):
+                bytes_per_voxel += 4
+            memory_mb = (total_voxels * bytes_per_voxel) / (1024 * 1024)
+            col.label(text=f"Est. Peak Memory: {memory_mb:.1f} MB")
 
             if total_voxels > 100_000_000:
                 col.label(text="Grid too large!", icon='CANCEL')
@@ -351,6 +371,7 @@ class VIEW3D_PT_dicomator_export_settings(Panel):
             dose_box = layout.column(align=True)
             dose_box.prop(props, "dose_type", text="Dose Type")
             dose_box.prop(props, "dose_summation_type", text="Summation Type")
+            dose_box.prop(props, "dose_accumulation", text="Dose Overlap")
 
         modality = getattr(props, "imaging_modality", None)
         is_mri = modality in MRI_MODALITIES

--- a/properties.py
+++ b/properties.py
@@ -385,6 +385,15 @@ class DICOMatorProperties(bpy.types.PropertyGroup):
         items=DOSE_SUMMATION_TYPE_ITEMS,
         default="PLAN",
     )
+    dose_accumulation: bpy.props.EnumProperty(
+        name="Dose Overlap",
+        description="How overlapping RT Dose meshes combine in the exported grid",
+        items=[
+            ("SUM", "Sum", "Overlapping dose volumes accumulate, matching how physical dose combines"),
+            ("OVERWRITE", "Overwrite", "The alphabetically last mesh wins in overlapping voxels"),
+        ],
+        default="SUM",
+    )
 
 
 __all__ = [

--- a/rtdose_export.py
+++ b/rtdose_export.py
@@ -36,7 +36,91 @@ import numpy as np
 from mathutils import Vector
 
 from . import constants as shared_constants
-from .constants import RTDOSE_SOP_CLASS
+from .constants import RTDOSE_SOP_CLASS, RTPLAN_SOP_CLASS
+
+
+def _export_minimal_rtplan(
+    output_dir: str,
+    *,
+    patient_name: str,
+    patient_id: str,
+    patient_sex: str,
+    series_description: str,
+    study_instance_uid: str,
+    frame_of_reference_uid: str,
+    series_number: int,
+    date_str: str,
+    time_str: str,
+    phase_index: Optional[int],
+) -> tuple[str, str]:
+    """Write a minimal RT Plan that the RT Dose object can reference.
+
+    ``ReferencedRTPlanSequence`` is Type 1C in the RT Dose IOD whenever
+    ``DoseSummationType`` is PLAN/FRACTION/BEAM, so a syntactically valid
+    plan object is required for strict importers. ``RTPlanGeometry`` is set
+    to TREATMENT_DEVICE because no structure set is referenced.
+
+    Returns ``(sop_instance_uid, filename)``.
+    """
+    pydicom = shared_constants.pydicom
+    Dataset = shared_constants.Dataset
+    FileDataset = shared_constants.FileDataset
+    generate_uid = shared_constants.generate_uid
+
+    plan_sop_instance_uid = generate_uid()
+
+    file_meta = Dataset()
+    file_meta.MediaStorageSOPClassUID = RTPLAN_SOP_CLASS
+    file_meta.MediaStorageSOPInstanceUID = plan_sop_instance_uid
+    file_meta.ImplementationClassUID = pydicom.uid.PYDICOM_IMPLEMENTATION_UID
+    file_meta.TransferSyntaxUID = pydicom.uid.ExplicitVRLittleEndian
+
+    plan = FileDataset(None, {}, file_meta=file_meta, preamble=b"\0" * 128)
+
+    plan.SOPClassUID = RTPLAN_SOP_CLASS
+    plan.SOPInstanceUID = plan_sop_instance_uid
+
+    plan.PatientName = patient_name
+    plan.PatientID = patient_id
+    plan.PatientBirthDate = ""
+    plan.PatientSex = patient_sex
+
+    plan.StudyInstanceUID = study_instance_uid
+    plan.StudyDate = date_str
+    plan.StudyTime = time_str
+    plan.StudyID = "1"
+    plan.AccessionNumber = "1"
+    plan.ReferringPhysicianName = ""
+
+    plan.Modality = "RTPLAN"
+    plan.SeriesInstanceUID = generate_uid()
+    plan.SeriesNumber = int(series_number)
+    plan.SeriesDescription = f"{series_description} - RT Plan"
+    plan.SeriesDate = date_str
+    plan.SeriesTime = time_str
+    plan.Manufacturer = "DICOMator"
+    plan.InstitutionName = "Virtual Hospital"
+    plan.StationName = "Blender"
+    plan.OperatorsName = ""
+
+    plan.FrameOfReferenceUID = frame_of_reference_uid
+    plan.PositionReferenceIndicator = ""
+
+    plan.InstanceNumber = "1"
+    plan.RTPlanLabel = "DICOMator"
+    plan.RTPlanName = "Synthetic plan"
+    plan.RTPlanDate = date_str
+    plan.RTPlanTime = time_str
+    plan.RTPlanGeometry = "TREATMENT_DEVICE"
+    plan.ApprovalStatus = "UNAPPROVED"
+
+    if phase_index is not None:
+        filename = os.path.join(output_dir, f"Phase_{int(phase_index):03d}_RTPlan.dcm")
+    else:
+        filename = os.path.join(output_dir, "RTPlan.dcm")
+    plan.save_as(filename, enforce_file_format=True)
+
+    return plan_sop_instance_uid, filename
 
 
 def export_rtdose_to_dicom(
@@ -57,6 +141,7 @@ def export_rtdose_to_dicom(
     series_instance_uid: Optional[str] = None,
     series_number: int = 1,
     phase_index: Optional[int] = None,
+    write_rtplan: bool = True,
 ) -> dict[str, str]:
     """Write ``dose_grid`` to a single multi-frame DICOM RT Dose file.
 
@@ -91,6 +176,10 @@ def export_rtdose_to_dicom(
     phase_index:
         Optional 1-based phase index used in the output filename when
         exporting a 4D sequence.
+    write_rtplan:
+        When True (default) a minimal companion RT Plan file is written and
+        referenced via ``ReferencedRTPlanSequence``, which the RT Dose IOD
+        requires (Type 1C) for the supported ``DoseSummationType`` values.
 
     Returns
     -------
@@ -156,6 +245,25 @@ def export_rtdose_to_dicom(
     series_instance_uid = series_instance_uid or generate_uid()
     sop_instance_uid = generate_uid()
 
+    plan_sop_instance_uid: Optional[str] = None
+    if write_rtplan:
+        try:
+            plan_sop_instance_uid, _plan_filename = _export_minimal_rtplan(
+                output_dir,
+                patient_name=patient_name,
+                patient_id=patient_id,
+                patient_sex=patient_sex,
+                series_description=series_description,
+                study_instance_uid=study_instance_uid,
+                frame_of_reference_uid=frame_of_reference_uid,
+                series_number=series_number,
+                date_str=date_str,
+                time_str=time_str,
+                phase_index=phase_index,
+            )
+        except Exception as exc:
+            return {"error": f"Error saving companion RT Plan DICOM file: {exc}"}
+
     try:
         file_meta = Dataset()
         file_meta.MediaStorageSOPClassUID = RTDOSE_SOP_CLASS
@@ -164,8 +272,6 @@ def export_rtdose_to_dicom(
         file_meta.TransferSyntaxUID = pydicom.uid.ExplicitVRLittleEndian
 
         ds = FileDataset(None, {}, file_meta=file_meta, preamble=b"\0" * 128)
-        ds.is_little_endian = True
-        ds.is_implicit_VR = False
 
         # --- SOP common ---
         ds.SOPClassUID = RTDOSE_SOP_CLASS
@@ -206,6 +312,9 @@ def export_rtdose_to_dicom(
         ds.ContentTime = time_str
         ds.ImageType = ["ORIGINAL", "PRIMARY", "AXIAL"]
         ds.NumberOfFrames = int(depth)
+        # Multi-frame module (PS3.3 C.7.6.6): FrameIncrementPointer is Type 1
+        # and for RT Dose must point at GridFrameOffsetVector (3004,000C).
+        ds.FrameIncrementPointer = pydicom.tag.Tag(0x3004, 0x000C)
 
         # --- Image plane ---
         # ImagePositionPatient is the center of the first voxel (PS3.3
@@ -239,6 +348,11 @@ def export_rtdose_to_dicom(
         ds.DoseType = str(dose_type or "PHYSICAL").upper()
         ds.DoseSummationType = str(dose_summation_type or "PLAN").upper()
         ds.DoseGridScaling = float(dose_grid_scaling)
+        if plan_sop_instance_uid is not None:
+            ref_plan = Dataset()
+            ref_plan.ReferencedSOPClassUID = RTPLAN_SOP_CLASS
+            ref_plan.ReferencedSOPInstanceUID = plan_sop_instance_uid
+            ds.ReferencedRTPlanSequence = [ref_plan]
 
         # Pixel data: all frames concatenated in slice order (C-contiguous).
         ds.PixelData = pixel_frames.tobytes()
@@ -248,7 +362,7 @@ def export_rtdose_to_dicom(
         else:
             filename = os.path.join(output_dir, "RTDose.dcm")
 
-        ds.save_as(filename)
+        ds.save_as(filename, enforce_file_format=True)
 
     except Exception as exc:
         return {"error": f"Error saving RT Dose DICOM file: {exc}"}

--- a/rtstruct_export.py
+++ b/rtstruct_export.py
@@ -29,11 +29,10 @@ from __future__ import annotations
 
 import os
 from datetime import datetime
-from typing import Optional, Sequence
+from typing import Generator, Optional, Sequence
 
 import bmesh
 import bpy
-import numpy as np
 
 from . import constants as shared_constants
 from .constants import RTSTRUCT_SOP_CLASS
@@ -77,8 +76,11 @@ def _walk_loops(cut_edges: list) -> list[list[tuple[float, float, float]]]:
     """Convert a set of BMEdge objects from a bisect into ordered closed loops.
 
     Each loop is returned as a list of ``(x, y, z)`` float tuples in Blender
-    world-space metres.  Only loops with three or more points are returned
-    (degenerate single-edge intersections are discarded).
+    world-space metres.  Only loops that actually close back on their start
+    vertex with three or more points are returned; open edge chains (from
+    non-watertight meshes) and degenerate single-edge intersections are
+    discarded, since emitting them as ``CLOSED_PLANAR`` contours would be
+    incorrect.
 
     The walk uses vertex object-identity comparisons, which are valid while
     the bmesh remains alive.
@@ -102,6 +104,7 @@ def _walk_loops(cut_edges: list) -> list[list[tuple[float, float, float]]]:
         unvisited.discard(start)
         prev = None
         current = start
+        closed = False
 
         while True:
             # Prefer vertices not yet visited; stop if we reach the start
@@ -112,6 +115,7 @@ def _walk_loops(cut_edges: list) -> list[list[tuple[float, float, float]]]:
             nxt = neighbors[0]
             if nxt is start and len(loop_verts) >= 3:
                 # Successfully closed the loop.
+                closed = True
                 break
             if nxt not in unvisited:
                 # Either reached a dead end or a vertex belonging to another
@@ -122,10 +126,63 @@ def _walk_loops(cut_edges: list) -> list[list[tuple[float, float, float]]]:
             prev = current
             current = nxt
 
-        if len(loop_verts) >= 3:
+        if closed and len(loop_verts) >= 3:
             loops.append([(float(v.co.x), float(v.co.y), float(v.co.z)) for v in loop_verts])
 
     return loops
+
+
+def _world_bmesh(
+    obj: bpy.types.Object,
+    depsgraph: bpy.types.Depsgraph,
+    *,
+    apply_modifiers: bool,
+) -> bmesh.types.BMesh:
+    """Return a new world-space bmesh for ``obj`` (caller must ``free()``)."""
+    if apply_modifiers and depsgraph is not None:
+        obj_eval = obj.evaluated_get(depsgraph)
+        mesh_data = obj_eval.to_mesh(preserve_all_data_layers=False, depsgraph=depsgraph)
+        world_matrix = obj_eval.matrix_world
+    else:
+        obj_eval = None
+        mesh_data = obj.data
+        world_matrix = obj.matrix_world
+
+    bm = bmesh.new()
+    try:
+        bm.from_mesh(mesh_data)
+        bm.transform(world_matrix)
+    except Exception:
+        bm.free()
+        raise
+    finally:
+        if obj_eval is not None:
+            obj_eval.to_mesh_clear()
+    return bm
+
+
+def _slice_plane(bm_base: bmesh.types.BMesh, z_m: float) -> list[list[tuple[float, float, float]]]:
+    """Bisect ``bm_base`` at world-space height ``z_m`` and return its loops."""
+    bm_slice = bm_base.copy()
+    try:
+        bm_slice.verts.ensure_lookup_table()
+        bm_slice.edges.ensure_lookup_table()
+        bm_slice.faces.ensure_lookup_table()
+
+        geom_all = list(bm_slice.verts) + list(bm_slice.edges) + list(bm_slice.faces)
+        result = bmesh.ops.bisect_plane(
+            bm_slice,
+            geom=geom_all,
+            dist=1e-5,
+            plane_co=(0.0, 0.0, float(z_m)),
+            plane_no=(0.0, 0.0, 1.0),
+            clear_outer=False,
+            clear_inner=False,
+        )
+        cut_edges = [elem for elem in result["geom_cut"] if isinstance(elem, bmesh.types.BMEdge)]
+        return _walk_loops(cut_edges)
+    finally:
+        bm_slice.free()
 
 
 def extract_contours_from_mesh(
@@ -161,53 +218,42 @@ def extract_contours_from_mesh(
         The caller is responsible for converting positions to millimetres
         when writing DICOM attributes.
     """
-    if apply_modifiers and depsgraph is not None:
-        obj_eval = obj.evaluated_get(depsgraph)
-        mesh_data = obj_eval.to_mesh(preserve_all_data_layers=False, depsgraph=depsgraph)
-        world_matrix = obj_eval.matrix_world
-    else:
-        mesh_data = obj.data
-        world_matrix = obj.matrix_world
-
     # Build a single base bmesh in world space to avoid repeated transforms.
-    bm_base = bmesh.new()
-    bm_base.from_mesh(mesh_data)
-    bm_base.transform(world_matrix)
-
-    # Release the temporary evaluated mesh now that we have the bmesh.
-    if apply_modifiers and depsgraph is not None:
-        obj_eval.to_mesh_clear()
-
-    contours: dict[float, list[list[tuple[float, float, float]]]] = {}
-
-    for z_m in z_positions_m:
-        bm_slice = bm_base.copy()
-        bm_slice.verts.ensure_lookup_table()
-        bm_slice.edges.ensure_lookup_table()
-        bm_slice.faces.ensure_lookup_table()
-
-        geom_all = list(bm_slice.verts) + list(bm_slice.edges) + list(bm_slice.faces)
-        result = bmesh.ops.bisect_plane(
-            bm_slice,
-            geom=geom_all,
-            dist=1e-5,
-            plane_co=(0.0, 0.0, float(z_m)),
-            plane_no=(0.0, 0.0, 1.0),
-            clear_outer=False,
-            clear_inner=False,
-        )
-
-        cut_edges = [elem for elem in result["geom_cut"] if isinstance(elem, bmesh.types.BMEdge)]
-        loops = _walk_loops(cut_edges)
-
-        contours[float(z_m)] = loops
-        bm_slice.free()
-
-    bm_base.free()
+    bm_base = _world_bmesh(obj, depsgraph, apply_modifiers=apply_modifiers)
+    try:
+        contours: dict[float, list[list[tuple[float, float, float]]]] = {}
+        for z_m in z_positions_m:
+            contours[float(z_m)] = _slice_plane(bm_base, z_m)
+    finally:
+        bm_base.free()
     return contours
 
 
 def export_rtstruct_to_dicom(
+    objects: Sequence[bpy.types.Object],
+    bbox_min: "mathutils.Vector",  # noqa: F821 – mathutils present in Blender
+    voxel_size: Sequence[float] | float,
+    n_slices: int,
+    output_dir: str,
+    depsgraph: bpy.types.Depsgraph,
+    **kwargs,
+) -> dict[str, str]:
+    """Write an RT Structure Set DICOM file for the supplied mesh objects.
+
+    Blocking wrapper around :func:`export_rtstruct_to_dicom_iter`; see that
+    function for parameter documentation.
+    """
+    generator = export_rtstruct_to_dicom_iter(
+        objects, bbox_min, voxel_size, n_slices, output_dir, depsgraph, **kwargs
+    )
+    while True:
+        try:
+            next(generator)
+        except StopIteration as stop:
+            return stop.value
+
+
+def export_rtstruct_to_dicom_iter(
     objects: Sequence[bpy.types.Object],
     bbox_min: "mathutils.Vector",  # noqa: F821 – mathutils present in Blender
     voxel_size: Sequence[float] | float,
@@ -229,8 +275,11 @@ def export_rtstruct_to_dicom(
     referenced_ct_series_instance_uid: Optional[str] = None,
     referenced_ct_sop_class_uid: Optional[str] = None,
     referenced_ct_sop_instance_uids: Optional[Sequence[str]] = None,
-) -> dict[str, str]:
+) -> Generator[tuple[int, int], None, dict[str, str]]:
     """Write an RT Structure Set DICOM file for the supplied mesh objects.
+
+    Generator variant: yields ``(planes_done, total_planes)`` while contours
+    are extracted, then returns the result dict.
 
     Parameters
     ----------
@@ -303,14 +352,21 @@ def export_rtstruct_to_dicom(
     # Extract contours for every object before building the DICOM dataset so
     # that bmesh operations are completed while we still hold references.
     all_contours: list[dict[float, list[list[tuple[float, float, float]]]]] = []
+    total_planes = max(1, len(objects) * len(z_positions_m))
+    planes_done = 0
     for obj in objects:
-        contours = extract_contours_from_mesh(
-            obj,
-            z_positions_m,
-            depsgraph,
-            apply_modifiers=apply_modifiers,
-        )
+        bm_base = _world_bmesh(obj, depsgraph, apply_modifiers=apply_modifiers)
+        try:
+            contours: dict[float, list[list[tuple[float, float, float]]]] = {}
+            for z_m in z_positions_m:
+                contours[float(z_m)] = _slice_plane(bm_base, z_m)
+                planes_done += 1
+                if planes_done % 8 == 0:
+                    yield planes_done, total_planes
+        finally:
+            bm_base.free()
         all_contours.append(contours)
+    yield planes_done, total_planes
 
     try:
         file_meta = Dataset()
@@ -320,8 +376,6 @@ def export_rtstruct_to_dicom(
         file_meta.TransferSyntaxUID = pydicom.uid.ExplicitVRLittleEndian
 
         ds = FileDataset(None, {}, file_meta=file_meta, preamble=b"\0" * 128)
-        ds.is_little_endian = True
-        ds.is_implicit_VR = False
 
         # --- SOP common ---
         ds.SOPClassUID = RTSTRUCT_SOP_CLASS
@@ -478,7 +532,7 @@ def export_rtstruct_to_dicom(
         else:
             filename = os.path.join(output_dir, "RTStruct.dcm")
 
-        ds.save_as(filename)
+        ds.save_as(filename, enforce_file_format=True)
 
     except Exception as exc:
         return {"error": f"Error saving RT Structure Set DICOM file: {exc}"}
@@ -489,4 +543,5 @@ def export_rtstruct_to_dicom(
 __all__ = [
     "extract_contours_from_mesh",
     "export_rtstruct_to_dicom",
+    "export_rtstruct_to_dicom_iter",
 ]

--- a/voxelization.py
+++ b/voxelization.py
@@ -1,8 +1,16 @@
-"""Mesh voxelization helpers used by the DICOMator add-on."""
+"""Mesh voxelization helpers used by the DICOMator add-on.
+
+All voxelizers share one ray-casting core (:func:`_voxelize_objects_iter`)
+that fills axis-aligned voxel columns by casting +Z rays through each mesh
+and pairing entry/exit hits. The core is a generator yielding
+``(processed_columns, total_columns)`` so callers (e.g. the modal export
+operator) can keep the Blender UI responsive; the blocking wrappers drive
+the generator to completion and forward progress to an optional callback.
+"""
 from __future__ import annotations
 
 import math
-from typing import Callable, Iterable, Optional, Sequence, Tuple
+from typing import Callable, Generator, Iterable, Optional, Sequence, Tuple
 
 import bpy
 import numpy as np
@@ -19,15 +27,41 @@ from .constants import (
 
 VectorLike = Sequence[float]
 VoxelSize = Sequence[float]
+ProgressCallback = Optional[Callable[[int, int], None]]
+Bounds = Tuple[float, float, float, float, float, float]
+VoxelizeResult = Tuple[np.ndarray, Vector, Tuple[int, int, int]]
+VoxelizeGenerator = Generator[Tuple[int, int], None, VoxelizeResult]
+
+#: Ray hits closer together than this distance (metres) are merged before
+#: entry/exit pairing. A ray grazing an edge shared by two faces reports the
+#: same surface twice; without merging, the duplicate flips the inside/outside
+#: parity and incorrectly fills the remainder of the voxel column.
+_HIT_MERGE_TOLERANCE_M = 1e-5
+
+#: Number of voxel columns processed between progress yields.
+_PROGRESS_CHUNK = 2048
 
 
-def _bvh_from_object(
+def _resolve_voxel_size(voxel_size: VoxelSize | float) -> Tuple[float, float, float]:
+    """Return ``(vx, vy, vz)`` in metres from a scalar or 3-sequence."""
+    if isinstance(voxel_size, Iterable):
+        components = [float(component) for component in voxel_size]
+        if len(components) != 3:
+            raise ValueError("voxel_size must be a scalar or a 3-component sequence")
+        return components[0], components[1], components[2]
+    return (float(voxel_size),) * 3
+
+
+def _object_geometry(
     obj: Object,
     depsgraph: Optional[bpy.types.Depsgraph] = None,
     *,
     apply_modifiers: bool = False,
-) -> BVHTree | None:
-    """Build a BVH tree in world space for ``obj``."""
+) -> Optional[Tuple[BVHTree, Tuple[float, float, float, float]]]:
+    """Build a world-space BVH for ``obj`` plus its world-space XY extent.
+
+    Returns ``None`` when the (evaluated) mesh has no vertices or faces.
+    """
     if apply_modifiers and depsgraph is not None:
         obj_eval = obj.evaluated_get(depsgraph)
         mesh = obj_eval.to_mesh(preserve_all_data_layers=False, depsgraph=depsgraph)
@@ -42,368 +76,350 @@ def _bvh_from_object(
         polygons = [list(poly.vertices) for poly in mesh.polygons]
     if not verts_world or not polygons:
         return None
-    return BVHTree.FromPolygons(verts_world, polygons)
+    min_x = min(vert.x for vert in verts_world)
+    max_x = max(vert.x for vert in verts_world)
+    min_y = min(vert.y for vert in verts_world)
+    max_y = max(vert.y for vert in verts_world)
+    return BVHTree.FromPolygons(verts_world, polygons), (min_x, max_x, min_y, max_y)
 
 
-def _bvh_from_object_base(obj: Object) -> BVHTree:
-    """Build a BVH from the object's base mesh without evaluating modifiers."""
-    mesh = obj.data
-    verts_world = [obj.matrix_world @ vert.co for vert in mesh.vertices]
-    polygons = [list(poly.vertices) for poly in mesh.polygons]
-    return BVHTree.FromPolygons(verts_world, polygons)
+def _objects_world_bounds(
+    objects: Sequence[Object],
+    depsgraph: Optional[bpy.types.Depsgraph],
+    *,
+    apply_modifiers: bool,
+) -> Bounds:
+    """Return the combined world-space bounds of ``objects``."""
+    min_x = min_y = min_z = float('inf')
+    max_x = max_y = max_z = float('-inf')
+    for obj in objects:
+        if apply_modifiers and depsgraph is not None:
+            obj_eval = obj.evaluated_get(depsgraph)
+            mesh = obj_eval.to_mesh(preserve_all_data_layers=False, depsgraph=depsgraph)
+            try:
+                for vertex in mesh.vertices:
+                    world_vertex = obj_eval.matrix_world @ vertex.co
+                    min_x = min(min_x, world_vertex.x)
+                    max_x = max(max_x, world_vertex.x)
+                    min_y = min(min_y, world_vertex.y)
+                    max_y = max(max_y, world_vertex.y)
+                    min_z = min(min_z, world_vertex.z)
+                    max_z = max(max_z, world_vertex.z)
+            finally:
+                obj_eval.to_mesh_clear()
+        else:
+            for corner in obj.bound_box:
+                world_corner = obj.matrix_world @ Vector(corner)
+                min_x = min(min_x, world_corner.x)
+                max_x = max(max_x, world_corner.x)
+                min_y = min(min_y, world_corner.y)
+                max_y = max(max_y, world_corner.y)
+                min_z = min(min_z, world_corner.z)
+                max_z = max(max_z, world_corner.z)
+    return min_x, max_x, min_y, max_y, min_z, max_z
 
 
-def voxelize_mesh(obj: Object, voxel_size: VectorLike | float = 1.0, padding: int = 1) -> Tuple[np.ndarray, Vector, Tuple[int, int, int]]:
-    """Voxelize ``obj`` by casting vertical rays."""
-    if isinstance(voxel_size, Iterable) and len(voxel_size) == 3:
-        vx, vy, vz = (float(component) for component in voxel_size)
+def _voxelize_objects_iter(
+    objects: Sequence[Object],
+    voxel_size: VoxelSize | float,
+    padding: int,
+    bbox_override: Optional[Bounds],
+    *,
+    apply_modifiers: bool,
+    depsgraph: Optional[bpy.types.Depsgraph],
+    value_for_object: Callable[[Object], float],
+    dtype: np.dtype,
+    background_value: float,
+    accumulate: bool,
+    label: str,
+) -> VoxelizeGenerator:
+    """Shared ray-casting voxelizer.
+
+    Fills a ``(width, height, depth)`` grid of ``dtype`` initialized to
+    ``background_value``. Meshes are processed in alphabetical name order;
+    when ``accumulate`` is False the alphabetically last mesh wins any
+    overlapping voxels, when True the per-object values are summed.
+    """
+    if not objects:
+        raise ValueError(f"No objects provided for {label} voxelization")
+
+    if apply_modifiers and depsgraph is None:
+        depsgraph = bpy.context.evaluated_depsgraph_get()
+
+    vx, vy, vz = _resolve_voxel_size(voxel_size)
+
+    if bbox_override is not None:
+        min_x, max_x, min_y, max_y, min_z, max_z = bbox_override
     else:
-        vx = vy = vz = float(voxel_size)
-
-    bvh = _bvh_from_object_base(obj)
-
-    bbox_corners = [obj.matrix_world @ Vector(corner) for corner in obj.bound_box]
-    min_x = min(corner.x for corner in bbox_corners) - padding * vx
-    max_x = max(corner.x for corner in bbox_corners) + padding * vx
-    min_y = min(corner.y for corner in bbox_corners) - padding * vy
-    max_y = max(corner.y for corner in bbox_corners) + padding * vy
-    min_z = min(corner.z for corner in bbox_corners) - padding * vz
-    max_z = max(corner.z for corner in bbox_corners) + padding * vz
+        min_x, max_x, min_y, max_y, min_z, max_z = _objects_world_bounds(
+            objects, depsgraph, apply_modifiers=apply_modifiers
+        )
+        min_x -= padding * vx
+        max_x += padding * vx
+        min_y -= padding * vy
+        max_y += padding * vy
+        min_z -= padding * vz
+        max_z += padding * vz
 
     width = max(1, int(math.ceil((max_x - min_x) / vx)))
     height = max(1, int(math.ceil((max_y - min_y) / vy)))
     depth = max(1, int(math.ceil((max_z - min_z) / vz)))
-
-    voxel_array = np.zeros((width, height, depth), dtype=np.uint8)
     origin = Vector((min_x, min_y, min_z))
+
+    grid = np.full((width, height, depth), background_value, dtype=dtype)
+
+    sorted_objects = sorted(
+        objects,
+        key=lambda obj: (obj.name.casefold(), obj.name),
+    )
+    object_data: list[tuple[BVHTree, float, int, int, int, int]] = []
+    for obj in sorted_objects:
+        geometry = _object_geometry(obj, depsgraph=depsgraph, apply_modifiers=apply_modifiers)
+        if geometry is None:
+            print(f"Skipping {label} voxelization for '{obj.name}': mesh has no faces.")
+            continue
+        bvh, (obj_min_x, obj_max_x, obj_min_y, obj_max_y) = geometry
+        # Rays outside the object's XY footprint cannot intersect it, so only
+        # the covered column range (plus one voxel of slack) is visited. For
+        # small objects inside a large grid this skips almost all columns.
+        ix0 = max(0, int(math.floor((obj_min_x - min_x) / vx)) - 1)
+        ix1 = min(width - 1, int(math.ceil((obj_max_x - min_x) / vx)) + 1)
+        iy0 = max(0, int(math.floor((obj_min_y - min_y) / vy)) - 1)
+        iy1 = min(height - 1, int(math.ceil((obj_max_y - min_y) / vy)) + 1)
+        if ix1 < ix0 or iy1 < iy0:
+            continue
+        object_data.append((bvh, float(value_for_object(obj)), ix0, ix1, iy0, iy1))
+
+    if not object_data:
+        raise ValueError("No voxelizable objects provided (all selected meshes had zero faces)")
+
+    print(f"Voxelizing {len(object_data)} object(s) into {width}x{height}x{depth} {label} grid...")
 
     xs = min_x + (np.arange(width) + 0.5) * vx
     ys = min_y + (np.arange(height) + 0.5) * vy
-
     z0_center = min_z + 0.5 * vz
     inv_dz = 1.0 / vz
     ray_dir = Vector((0.0, 0.0, 1.0))
+    ray_start_z = min_z - 2.0 * vz
     max_dist = (max_z - min_z) + 4.0 * vz
     epsilon = 1e-6
 
-    total_columns = width * height
-    processed_columns = 0
+    total_columns = max(
+        1,
+        sum((ix1 - ix0 + 1) * (iy1 - iy0 + 1) for _bvh, _value, ix0, ix1, iy0, iy1 in object_data),
+    )
+    processed = 0
 
-    for ix in range(width):
-        x_world = float(xs[ix])
-        for iy in range(height):
-            y_world = float(ys[iy])
-            origin_ray = Vector((x_world, y_world, min_z - 2.0 * vz))
-            hits_z: list[float] = []
+    for bvh, value, ix0, ix1, iy0, iy1 in object_data:
+        for ix in range(ix0, ix1 + 1):
+            x_world = float(xs[ix])
+            for iy in range(iy0, iy1 + 1):
+                y_world = float(ys[iy])
+                origin_ray = Vector((x_world, y_world, ray_start_z))
+                hits_z: list[float] = []
+                while True:
+                    location, _normal, _face_index, _distance = bvh.ray_cast(origin_ray, ray_dir, max_dist)
+                    if location is None:
+                        break
+                    hits_z.append(location.z)
+                    origin_ray = Vector((location.x, location.y, location.z + epsilon))
 
-            while True:
-                location, _normal, _face_index, _distance = bvh.ray_cast(origin_ray, ray_dir, max_dist)
-                if location is None:
-                    break
-                hits_z.append(location.z)
-                origin_ray = Vector((location.x, location.y, location.z + epsilon))
+                if hits_z:
+                    hits_z.sort()
+                    merged: list[float] = []
+                    for hit_z in hits_z:
+                        if not merged or (hit_z - merged[-1]) > _HIT_MERGE_TOLERANCE_M:
+                            merged.append(hit_z)
+                    for start in range(0, len(merged) - 1, 2):
+                        lower = merged[start]
+                        upper = merged[start + 1]
+                        start_idx = int(math.ceil((lower - z0_center) * inv_dz))
+                        end_idx = int(math.floor((upper - z0_center) * inv_dz))
+                        if end_idx >= start_idx:
+                            s = max(0, start_idx)
+                            e = min(depth - 1, end_idx)
+                            if e >= s:
+                                if accumulate:
+                                    grid[ix, iy, s:e + 1] += value
+                                else:
+                                    grid[ix, iy, s:e + 1] = value
 
-            if hits_z:
-                hits_z.sort()
-                for start in range(0, len(hits_z) - 1, 2):
-                    lower = hits_z[start]
-                    upper = hits_z[start + 1]
-                    start_idx = int(math.ceil((lower - z0_center) * inv_dz))
-                    end_idx = int(math.floor((upper - z0_center) * inv_dz))
-                    if end_idx >= start_idx:
-                        s = max(0, start_idx)
-                        e = min(depth - 1, end_idx)
-                        if e >= s:
-                            voxel_array[ix, iy, s:e + 1] = 1
+                processed += 1
+                if processed % _PROGRESS_CHUNK == 0:
+                    yield processed, total_columns
 
-            processed_columns += 1
-            if processed_columns % 10000 == 0:
-                print(f"  processed columns: {processed_columns}/{total_columns} ({(processed_columns/total_columns)*100:.1f}%)")
+    print(f"Voxelization complete ({label} grid).")
+    yield total_columns, total_columns
+    return grid, origin, (width, height, depth)
 
-    print(f"Voxelization complete. Filled voxels: {int(voxel_array.sum())}/{voxel_array.size}")
-    return voxel_array, origin, (width, height, depth)
+
+def _drive(generator: VoxelizeGenerator, progress_callback: ProgressCallback) -> VoxelizeResult:
+    """Run a voxelize generator to completion, forwarding progress."""
+    while True:
+        try:
+            current, total = next(generator)
+        except StopIteration as stop:
+            return stop.value
+        if progress_callback:
+            progress_callback(current, total)
+
+
+def voxelize_objects_to_hu_iter(
+    objects: Sequence[Object],
+    voxel_size: VoxelSize | float = 1.0,
+    padding: int = 1,
+    bbox_override: Optional[Bounds] = None,
+    *,
+    apply_modifiers: bool = False,
+    depsgraph: Optional[bpy.types.Depsgraph] = None,
+    background_value: float = AIR_DENSITY,
+) -> VoxelizeGenerator:
+    """Generator variant of :func:`voxelize_objects_to_hu`.
+
+    ``background_value`` fills voxels not covered by any mesh. CT exports use
+    air (-1000 HU); MR exports should pass 0 (signal void) instead.
+    """
+    def hu_for_object(obj: Object) -> float:
+        hu_value = float(getattr(obj, "dicomator_hu", DEFAULT_DENSITY))
+        return max(MIN_HU_VALUE, min(MAX_HU_VALUE, hu_value))
+
+    return _voxelize_objects_iter(
+        objects,
+        voxel_size,
+        padding,
+        bbox_override,
+        apply_modifiers=apply_modifiers,
+        depsgraph=depsgraph,
+        value_for_object=hu_for_object,
+        dtype=np.int16,
+        background_value=float(background_value),
+        accumulate=False,
+        label="HU",
+    )
 
 
 def voxelize_objects_to_hu(
     objects: Sequence[Object],
     voxel_size: VoxelSize | float = 1.0,
     padding: int = 1,
-    progress_callback: Optional[Callable[[int, int], None]] = None,
-    bbox_override: Optional[Tuple[float, float, float, float, float, float]] = None,
+    progress_callback: ProgressCallback = None,
+    bbox_override: Optional[Bounds] = None,
     *,
     apply_modifiers: bool = False,
     depsgraph: Optional[bpy.types.Depsgraph] = None,
-) -> Tuple[np.ndarray, Vector, Tuple[int, int, int]]:
-    """Voxelize multiple objects into a single HU grid.
+    background_value: float = AIR_DENSITY,
+) -> VoxelizeResult:
+    """Voxelize multiple objects into a single intensity grid.
 
     Overlapping solids resolve deterministically: meshes are processed in
     alphabetical order by name and the alphabetically last mesh wins any
     conflicting voxels.
     """
-    if not objects:
-        raise ValueError("No objects provided for voxelization")
-
-    if apply_modifiers and depsgraph is None:
-        depsgraph = bpy.context.evaluated_depsgraph_get()
-
-    if isinstance(voxel_size, Iterable) and len(voxel_size) == 3:
-        vx, vy, vz = (float(component) for component in voxel_size)
-    else:
-        vx = vy = vz = float(voxel_size)
-
-    if bbox_override is not None:
-        min_x, max_x, min_y, max_y, min_z, max_z = bbox_override
-    else:
-        min_x = min_y = min_z = float('inf')
-        max_x = max_y = max_z = float('-inf')
-        for obj in objects:
-            if apply_modifiers and depsgraph is not None:
-                obj_eval = obj.evaluated_get(depsgraph)
-                mesh = obj_eval.to_mesh(preserve_all_data_layers=False, depsgraph=depsgraph)
-                try:
-                    for vertex in mesh.vertices:
-                        world_vertex = obj_eval.matrix_world @ vertex.co
-                        min_x = min(min_x, world_vertex.x)
-                        max_x = max(max_x, world_vertex.x)
-                        min_y = min(min_y, world_vertex.y)
-                        max_y = max(max_y, world_vertex.y)
-                        min_z = min(min_z, world_vertex.z)
-                        max_z = max(max_z, world_vertex.z)
-                finally:
-                    obj_eval.to_mesh_clear()
-            else:
-                for corner in obj.bound_box:
-                    world_corner = obj.matrix_world @ Vector(corner)
-                    min_x = min(min_x, world_corner.x)
-                    max_x = max(max_x, world_corner.x)
-                    min_y = min(min_y, world_corner.y)
-                    max_y = max(max_y, world_corner.y)
-                    min_z = min(min_z, world_corner.z)
-                    max_z = max(max_z, world_corner.z)
-        min_x -= padding * vx
-        max_x += padding * vx
-        min_y -= padding * vy
-        max_y += padding * vy
-        min_z -= padding * vz
-        max_z += padding * vz
-
-    width = max(1, int(math.ceil((max_x - min_x) / vx)))
-    height = max(1, int(math.ceil((max_y - min_y) / vy)))
-    depth = max(1, int(math.ceil((max_z - min_z) / vz)))
-    origin = Vector((min_x, min_y, min_z))
-
-    print(f"Voxelizing {len(objects)} objects into {width}x{height}x{depth} HU grid...")
-
-    hu_array = np.full((width, height, depth), int(AIR_DENSITY), dtype=np.int16)
-
-    xs = min_x + (np.arange(width) + 0.5) * vx
-    ys = min_y + (np.arange(height) + 0.5) * vy
-    z0_center = min_z + 0.5 * vz
-    inv_dz = 1.0 / vz
-    ray_dir = Vector((0.0, 0.0, 1.0))
-    max_dist = (max_z - min_z) + 4.0 * vz
-    epsilon = 1e-6
-
-    sorted_objects = sorted(
-        objects,
-        key=lambda obj: (obj.name.casefold(), obj.name),
+    return _drive(
+        voxelize_objects_to_hu_iter(
+            objects,
+            voxel_size,
+            padding,
+            bbox_override,
+            apply_modifiers=apply_modifiers,
+            depsgraph=depsgraph,
+            background_value=background_value,
+        ),
+        progress_callback,
     )
-    object_data: list[tuple[str, BVHTree, np.int16]] = []
-    for obj in sorted_objects:
-        bvh = _bvh_from_object(obj, depsgraph=depsgraph, apply_modifiers=apply_modifiers)
-        if bvh is None:
-            print(f"Skipping HU voxelization for '{obj.name}': mesh has no faces.")
-            continue
-        hu_value = float(getattr(obj, 'dicomator_hu', DEFAULT_DENSITY))
-        hu_value = max(MIN_HU_VALUE, min(MAX_HU_VALUE, hu_value))
-        object_data.append((obj.name, bvh, np.int16(hu_value)))
-    if not object_data:
-        raise ValueError("No voxelizable objects provided (all selected meshes had zero faces)")
 
-    total_columns = width * height
-    processed_columns = 0
 
-    for ix in range(width):
-        x_world = float(xs[ix])
-        for iy in range(height):
-            y_world = float(ys[iy])
-            for _name, bvh, hu_value in object_data:
-                origin_ray = Vector((x_world, y_world, min_z - 2.0 * vz))
-                hits_z: list[float] = []
-                while True:
-                    location, _normal, _face_index, _distance = bvh.ray_cast(origin_ray, ray_dir, max_dist)
-                    if location is None:
-                        break
-                    hits_z.append(location.z)
-                    origin_ray = Vector((location.x, location.y, location.z + epsilon))
-                if hits_z:
-                    hits_z.sort()
-                    for start in range(0, len(hits_z) - 1, 2):
-                        lower = hits_z[start]
-                        upper = hits_z[start + 1]
-                        start_idx = int(math.ceil((lower - z0_center) * inv_dz))
-                        end_idx = int(math.floor((upper - z0_center) * inv_dz))
-                        if end_idx >= start_idx:
-                            s = max(0, start_idx)
-                            e = min(depth - 1, end_idx)
-                            if e >= s:
-                                # Alphabetical sorting ensures the final mesh in the
-                                # list (last name) overwrites earlier assignments
-                                # wherever voxel solids overlap.
-                                hu_array[ix, iy, s:e + 1] = hu_value
-            processed_columns += 1
-            if progress_callback and (processed_columns % 5000) == 0:
-                progress_callback(processed_columns, total_columns)
-            if processed_columns % 20000 == 0:
-                print(f"  processed columns: {processed_columns}/{total_columns} ({(processed_columns/total_columns)*100:.1f}%)")
+def voxelize_objects_to_dose_iter(
+    objects: Sequence[Object],
+    voxel_size: VoxelSize | float = 1.0,
+    padding: int = 1,
+    bbox_override: Optional[Bounds] = None,
+    *,
+    apply_modifiers: bool = False,
+    depsgraph: Optional[bpy.types.Depsgraph] = None,
+    accumulate: bool = True,
+) -> VoxelizeGenerator:
+    """Generator variant of :func:`voxelize_objects_to_dose`."""
+    def dose_for_object(obj: Object) -> float:
+        # Clamp dose to non-negative values; negative dose has no physical meaning.
+        return max(0.0, float(getattr(obj, "dicomator_dose", 0.0)))
 
-    print("Voxelization complete (multi-object HU grid).")
-    if progress_callback:
-        progress_callback(total_columns, total_columns)
-    return hu_array, origin, (width, height, depth)
+    return _voxelize_objects_iter(
+        objects,
+        voxel_size,
+        padding,
+        bbox_override,
+        apply_modifiers=apply_modifiers,
+        depsgraph=depsgraph,
+        value_for_object=dose_for_object,
+        dtype=np.float32,
+        background_value=0.0,
+        accumulate=accumulate,
+        label="dose",
+    )
 
 
 def voxelize_objects_to_dose(
     objects: Sequence[Object],
     voxel_size: VoxelSize | float = 1.0,
     padding: int = 1,
-    progress_callback: Optional[Callable[[int, int], None]] = None,
-    bbox_override: Optional[Tuple[float, float, float, float, float, float]] = None,
+    progress_callback: ProgressCallback = None,
+    bbox_override: Optional[Bounds] = None,
     *,
     apply_modifiers: bool = False,
     depsgraph: Optional[bpy.types.Depsgraph] = None,
-) -> Tuple[np.ndarray, Vector, Tuple[int, int, int]]:
+    accumulate: bool = True,
+) -> VoxelizeResult:
     """Voxelize multiple objects into a dose grid (Gy).
 
-    Mirrors :func:`voxelize_objects_to_hu` exactly but reads
-    ``obj.dicomator_dose`` (float, Gy) per object instead of
-    ``obj.dicomator_hu``.  Returns a ``float32`` array (background = 0.0 Gy).
-    Overlapping solids resolve in alphabetical name order: the last mesh in
-    the sorted list overwrites earlier assignments wherever voxels overlap.
+    Reads ``obj.dicomator_dose`` (float, Gy) per object and returns a
+    ``float32`` array (background = 0.0 Gy). When ``accumulate`` is True
+    (default) overlapping dose volumes sum, which matches how physical dose
+    from multiple sources combines; when False the alphabetically last mesh
+    overwrites earlier assignments wherever voxels overlap.
     """
-    if not objects:
-        raise ValueError("No objects provided for dose voxelization")
-
-    if apply_modifiers and depsgraph is None:
-        depsgraph = bpy.context.evaluated_depsgraph_get()
-
-    if isinstance(voxel_size, Iterable) and len(voxel_size) == 3:
-        vx, vy, vz = (float(component) for component in voxel_size)
-    else:
-        vx = vy = vz = float(voxel_size)
-
-    if bbox_override is not None:
-        min_x, max_x, min_y, max_y, min_z, max_z = bbox_override
-    else:
-        min_x = min_y = min_z = float('inf')
-        max_x = max_y = max_z = float('-inf')
-        for obj in objects:
-            if apply_modifiers and depsgraph is not None:
-                obj_eval = obj.evaluated_get(depsgraph)
-                mesh = obj_eval.to_mesh(preserve_all_data_layers=False, depsgraph=depsgraph)
-                try:
-                    for vertex in mesh.vertices:
-                        world_vertex = obj_eval.matrix_world @ vertex.co
-                        min_x = min(min_x, world_vertex.x)
-                        max_x = max(max_x, world_vertex.x)
-                        min_y = min(min_y, world_vertex.y)
-                        max_y = max(max_y, world_vertex.y)
-                        min_z = min(min_z, world_vertex.z)
-                        max_z = max(max_z, world_vertex.z)
-                finally:
-                    obj_eval.to_mesh_clear()
-            else:
-                for corner in obj.bound_box:
-                    world_corner = obj.matrix_world @ Vector(corner)
-                    min_x = min(min_x, world_corner.x)
-                    max_x = max(max_x, world_corner.x)
-                    min_y = min(min_y, world_corner.y)
-                    max_y = max(max_y, world_corner.y)
-                    min_z = min(min_z, world_corner.z)
-                    max_z = max(max_z, world_corner.z)
-        min_x -= padding * vx
-        max_x += padding * vx
-        min_y -= padding * vy
-        max_y += padding * vy
-        min_z -= padding * vz
-        max_z += padding * vz
-
-    width = max(1, int(math.ceil((max_x - min_x) / vx)))
-    height = max(1, int(math.ceil((max_y - min_y) / vy)))
-    depth = max(1, int(math.ceil((max_z - min_z) / vz)))
-    origin = Vector((min_x, min_y, min_z))
-
-    print(f"Voxelizing {len(objects)} objects into {width}x{height}x{depth} dose grid (Gy)...")
-
-    # Background dose is 0.0 Gy (no radiation outside defined volumes).
-    dose_array = np.zeros((width, height, depth), dtype=np.float32)
-
-    xs = min_x + (np.arange(width) + 0.5) * vx
-    ys = min_y + (np.arange(height) + 0.5) * vy
-    z0_center = min_z + 0.5 * vz
-    inv_dz = 1.0 / vz
-    ray_dir = Vector((0.0, 0.0, 1.0))
-    max_dist = (max_z - min_z) + 4.0 * vz
-    epsilon = 1e-6
-
-    sorted_objects = sorted(
-        objects,
-        key=lambda obj: (obj.name.casefold(), obj.name),
+    return _drive(
+        voxelize_objects_to_dose_iter(
+            objects,
+            voxel_size,
+            padding,
+            bbox_override,
+            apply_modifiers=apply_modifiers,
+            depsgraph=depsgraph,
+            accumulate=accumulate,
+        ),
+        progress_callback,
     )
-    object_data: list[tuple[str, BVHTree, float]] = []
-    for obj in sorted_objects:
-        bvh = _bvh_from_object(obj, depsgraph=depsgraph, apply_modifiers=apply_modifiers)
-        if bvh is None:
-            print(f"Skipping dose voxelization for '{obj.name}': mesh has no faces.")
-            continue
-        # Clamp dose to non-negative values; negative dose has no physical meaning.
-        dose_value = max(0.0, float(getattr(obj, "dicomator_dose", 0.0)))
-        object_data.append((obj.name, bvh, dose_value))
-    if not object_data:
-        raise ValueError("No voxelizable objects provided (all selected meshes had zero faces)")
 
-    total_columns = width * height
-    processed_columns = 0
 
-    for ix in range(width):
-        x_world = float(xs[ix])
-        for iy in range(height):
-            y_world = float(ys[iy])
-            for _name, bvh, dose_value in object_data:
-                origin_ray = Vector((x_world, y_world, min_z - 2.0 * vz))
-                hits_z: list[float] = []
-                while True:
-                    location, _normal, _face_index, _distance = bvh.ray_cast(origin_ray, ray_dir, max_dist)
-                    if location is None:
-                        break
-                    hits_z.append(location.z)
-                    origin_ray = Vector((location.x, location.y, location.z + epsilon))
-                if hits_z:
-                    hits_z.sort()
-                    for start in range(0, len(hits_z) - 1, 2):
-                        lower = hits_z[start]
-                        upper = hits_z[start + 1]
-                        start_idx = int(math.ceil((lower - z0_center) * inv_dz))
-                        end_idx = int(math.floor((upper - z0_center) * inv_dz))
-                        if end_idx >= start_idx:
-                            s = max(0, start_idx)
-                            e = min(depth - 1, end_idx)
-                            if e >= s:
-                                dose_array[ix, iy, s:e + 1] = dose_value
-            processed_columns += 1
-            if progress_callback and (processed_columns % 5000) == 0:
-                progress_callback(processed_columns, total_columns)
-            if processed_columns % 20000 == 0:
-                print(f"  processed columns: {processed_columns}/{total_columns} ({(processed_columns/total_columns)*100:.1f}%)")
-
-    print("Dose voxelization complete.")
-    if progress_callback:
-        progress_callback(total_columns, total_columns)
-    return dose_array, origin, (width, height, depth)
+def voxelize_mesh(
+    obj: Object,
+    voxel_size: VectorLike | float = 1.0,
+    padding: int = 1,
+) -> VoxelizeResult:
+    """Voxelize a single object's base mesh into a binary occupancy grid."""
+    return _drive(
+        _voxelize_objects_iter(
+            [obj],
+            voxel_size,
+            padding,
+            None,
+            apply_modifiers=False,
+            depsgraph=None,
+            value_for_object=lambda _obj: 1.0,
+            dtype=np.uint8,
+            background_value=0.0,
+            accumulate=False,
+            label="occupancy",
+        ),
+        None,
+    )
 
 
 __all__ = [
     "voxelize_mesh",
     "voxelize_objects_to_hu",
+    "voxelize_objects_to_hu_iter",
     "voxelize_objects_to_dose",
+    "voxelize_objects_to_dose_iter",
 ]


### PR DESCRIPTION
Bug fixes:
- constants: wrap wheel extraction in try/except so a read-only extension
  directory or corrupt archive no longer breaks add-on registration
- voxelization: MR exports now use 0 (signal void) as the background value
  instead of CT air (-1000 HU); merge near-duplicate ray hits so grazing a
  shared edge no longer flips fill parity and streaks whole columns
- dicom_export: add MR Image module attributes (scanning sequence, TR/TE,
  etc.) so MR series pass IOD validation; restrict RescaleIntercept/Slope to
  CT; drop deprecated pydicom 2.x is_little_endian/is_implicit_VR and save
  with enforce_file_format=True
- rtdose_export: add FrameIncrementPointer (Type 1, multi-frame module) and
  write a minimal companion RT Plan referenced via ReferencedRTPlanSequence
  (Type 1C for PLAN/FRACTION/BEAM summation)
- rtstruct_export: discard open edge chains instead of emitting them as
  CLOSED_PLANAR contours; free bmesh data with try/finally
- operators: 4D phase labels now start at 0% (4DCT convention)
- __init__: remove always-true "bpy in locals" reload guard

Improvements:
- voxelization: merge HU/dose voxelizers into one core; restrict ray casting
  to each object's XY footprint (large speedup for small objects in big grids)
- operators: export now runs as a modal, ESC-cancellable job that keeps the
  UI responsive; warn about non-manifold meshes before export
- RT Dose: overlapping dose meshes sum by default (physical behaviour) with
  an Overwrite option in the dose settings
- DRR: 4D exports use a fixed physical intensity mapping so phases are
  comparable; single-phase keeps percentile auto-windowing
- panels: memory estimate accounts for float32 working copies
- manifest: add linux-x64/macos-x64 (bundled wheel is pure Python); bump to 3.2.0

Validated with python -m compileall plus round-trip tests of the RT Dose/
RT Plan datasets against the bundled pydicom 3.0.1 wheel; generator/modal
plumbing covered by bpy-free simulations. Manual Blender smoke test still
recommended.