### PR TITLE
Fix review findings and target Blender 5.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,15 +16,16 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      - name: Create zip (just the code)
+      - name: Create extension zip (manifest at zip root)
         run: |
-          zip -r test.zip . \
+          zip -r dicomator.zip . \
             -x ".git/**" \
                ".github/**" \
                ".gitignore" \
+               "AGENTS.md" \
                "download_wheels.py"
 
-      - name: Upload test.zip to this release
+      - name: Upload dicomator.zip to this release
         uses: softprops/action-gh-release@v2
         with:
           files: dicomator.zip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # DICOMator Contributor Notes
 
 ## Repository Overview
-- **Purpose:** Blender 5.1.1+ add-on that voxelizes mesh objects and exports them as CT-style DICOM series, optionally layering synthetic artifacts, and can generate digitally reconstructed radiographs (DRRs) and synthetic radiotherapy data (RT-DOSE and RT-STRUCT).
+- **Purpose:** Blender 5.1+ add-on that voxelizes mesh objects and exports them as CT-style DICOM series, optionally layering synthetic artifacts, and can generate digitally reconstructed radiographs (DRRs) and synthetic radiotherapy data (RT-DOSE and RT-STRUCT).
 - **Key modules:**
   - `__init__.py` – Blender registration entry point and exported API.
   - `properties.py` – `bpy.types.PropertyGroup` definitions backing the add-on UI.
@@ -15,7 +15,7 @@
   - `rtstruct_export.py` – Exports mesh-derived contours as an RT-STRUCT DICOM object (Region of Interest sequences) via pydicom.  - `download_wheels.py` / `wheels/` – Optional vendor wheels for Blender’s bundled Python.
 
 ## Coding Guidelines
-- Target **Python 3.13** (matches Blender 5.1.1 runtime).
+- Target **Python 3.13** (matches the Blender 5.1 runtime).
 - Follow **PEP 8** conventions: 4-space indentation, descriptive naming, and module-level docstrings. Keep public helpers exported through `__all__` lists when the surrounding module already uses them.
 - Prefer explicit type hints (`-> None`, concrete collection types) and keep docstrings concise but informative. Use f-strings for string interpolation.
 - Blender-specific code (`bpy`, `mathutils`) should remain importable without running inside Blender. Avoid executing Blender ops at import time; confine them to functions/operators.
@@ -25,9 +25,9 @@
 - Ensure the code is written and structured in a way that is easily understandable by a medical physicist.
 
 ## Testing & Validation
-- The repository does not ship automated unit tests. **Before committing changes, run:**
+- The repository does not ship automated unit tests. **Before committing changes, run (from the repository root):**
   ```bash
-  python -m compileall DICOMator
+  python -m compileall .
   ```
   This catches syntax errors without requiring Blender.
 - For features that touch Blender interaction, perform a quick manual smoke test inside Blender if possible (not enforced here, but recommended).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Blender add-on that converts selected mesh objects into DICOM outputs for synthe
   - Each selected mesh is tagged as **Image**, **RT Dose**, or **RT Structure** via the Objects panel
   - Image objects: set HU/intensity value or pick a tissue preset; overlapping meshes resolve by alphabetical name order
   - RT Dose objects: assign an absorbed dose value (Gy) per mesh; voxels within the mesh receive that dose
-  - RT Structure objects: assign an ROI type (GTV, CTV, PTV, OAR, External, Other); contours are extracted at each CT slice plane
+  - RT Structure objects: assign an ROI type (GTV, CTV, PTV, OAR, External, Control, Avoidance, Organ, Treated Volume, Irradiated Volume); contours are extracted at each CT slice plane
 - **Tissue intensity presets**
   - Choose CT, T1 MR, or T2 MR modalities and assign tissue presets from a curated table
   - Selected presets automatically populate per-object intensities while still allowing manual overrides
@@ -47,28 +47,28 @@ Blender add-on that converts selected mesh objects into DICOM outputs for synthe
   - Mesh objects tagged as RT Structure are sliced at each CT Z-plane using bmesh bisection
   - Closed planar contours are extracted from cut edges and written as a DICOM RT Structure Set (`RTStructureSetStorage`)
   - ROI display colour is read from the object's first material diffuse colour, or a clinical-style palette is used as a fallback
-  - Supports ROI types GTV, CTV, PTV, OAR, External, and Other
+  - Supports ROI types GTV, CTV, PTV, OAR, External, Control, Avoidance, Organ, Treated Volume, and Irradiated Volume
 - **Selection insights**
   - Live estimates of grid dimensions, voxel counts, and approximate memory usage before export
 
 ## Requirements
 
-- Blender 5.1.1+ (Python 3.13 runtime)
+- Blender 5.1+ (Python 3.13 runtime); `blender_version_min` in the extension manifest is `5.1.0`
 - NumPy (bundled with Blender, used for grid operations)
 - pydicom 3.0.1+ (required for DICOM export; vendored in `wheels/`; the add-on warns and disables export if missing)
 - Optional helper wheels
   - Run `download_wheels.py` to download a Blender-targeted `pydicom` wheel into `./wheels` (defaults to Blender 5.1 / Python 3.13 tags, overrideable via environment variables)
 
-## Blender 5.1.1 compatibility
+## Blender 5.1 compatibility
 
-- Targets the Blender 5.1.1 Python 3.13 runtime (VFX Platform 2026).
+- Targets the Blender 5.1 Python 3.13 runtime (VFX Platform 2026).
 - The add-on has **no OpenVDB dependency**. Voxelization is performed with Blender mesh evaluation, `mathutils.bvhtree.BVHTree`, and NumPy arrays.
 - NumPy 2.x compatibility is maintained by using `np.asarray(...)` rather than `np.array(..., copy=False)` throughout.
 - Extension packaging advertises only the vendored `pydicom 3.0.1` (`py3-none-any`) wheel, which requires Python 3.10+ and is compatible with NumPy 2.x and Python 3.13.
 
 ## Installation
 
-Blender 5.1.1 uses the **Extensions** workflow for add-ons.
+Blender uses the **Extensions** workflow for add-ons.
 
 1. Create an extension zip from this repository root (the zip must include `blender_manifest.toml` at the top level).
 2. In Blender, open **Edit → Preferences → Extensions**.
@@ -93,7 +93,7 @@ Dependency note:
    - **Objects** – For each selected mesh, choose its **DICOM Type**:
      - *Image*: assign HU/intensity values or pick modality-aware tissue presets. When meshes overlap, alphabetical ordering of object names decides the winning intensity (last name wins).
      - *RT Dose*: assign an absorbed dose in Gy. Voxels within the mesh receive that dose value when the RT Dose grid is built.
-     - *RT Structure*: assign an ROI type (GTV, CTV, PTV, OAR, External, Other). The object's material diffuse colour is used as the ROI display colour in the structure set; a clinical-style palette is used if no material is assigned.
+     - *RT Structure*: assign an ROI type (GTV, CTV, PTV, OAR, External, Control, Avoidance, Organ, Treated Volume, Irradiated Volume). The object's material diffuse colour is used as the ROI display colour in the structure set; a clinical-style palette is used if no material is assigned.
    - Enable the desired outputs in the main panel:
      - **Image** – writes CT or MR slices from Image meshes
      - **DRR** – writes a camera-based projection from Image meshes
@@ -166,7 +166,7 @@ Notes:
 <img src="https://github.com/user-attachments/assets/eca22ede-4a6f-47ca-a82c-e53dccb0649d" alt="skull_dose_lat" width="420" />
 <img src="https://github.com/user-attachments/assets/8eb7a3ce-fbaf-4d7d-b70d-33e7b808e0fd" alt="Lung_geometry" width="420" />
 <img src="https://github.com/user-attachments/assets/77e204bd-2a70-46bb-af8f-c3327ef7eb8f" alt="Lung" width="420" />
-<img width="359" height="362" alt="SuzanneXRay" src="https://github.com/user-attachments/assets/2951918f-773b-4505-88cc-4086dfd64b2c" width="420"/>
+<img height="362" alt="SuzanneXRay" src="https://github.com/user-attachments/assets/2951918f-773b-4505-88cc-4086dfd64b2c" width="420"/>
 
 ## Performance and limits
 

--- a/__init__.py
+++ b/__init__.py
@@ -53,11 +53,13 @@ from .panels import (
 from .properties import DICOMatorProperties, update_object_material
 from .voxelization import voxelize_mesh, voxelize_objects_to_dose, voxelize_objects_to_hu
 
+# Legacy add-on metadata; ignored when installed as an extension (the
+# blender_manifest.toml is authoritative). Kept in sync per AGENTS.md.
 bl_info = {
     "name": "DICOMator",
     "author": "Michael Douglass",
-    "version": (3, 2, 0),
-    "blender": (4, 2, 0),
+    "version": (3, 3, 0),
+    "blender": (5, 1, 0),
     "location": "View3D > Sidebar > DICOMator",
     "description": "Converts mesh objects into synthetic CT/MR series or camera-based DRR DICOM images",
     "warning": "",
@@ -81,56 +83,53 @@ def register() -> None:  # pragma: no cover - Blender registration
     for cls in classes:
         bpy.utils.register_class(cls)
 
-    if not hasattr(bpy.types.Scene, "dicomator_props"):
-        bpy.types.Scene.dicomator_props = PointerProperty(type=DICOMatorProperties)
+    # Assign unconditionally: guarding with hasattr() would keep a stale
+    # definition from a previous registration (e.g. an older add-on version)
+    # bound instead of the current one. Re-assignment is idempotent.
+    bpy.types.Scene.dicomator_props = PointerProperty(type=DICOMatorProperties)
 
-    if not hasattr(bpy.types.Object, "dicomator_hu"):
-        bpy.types.Object.dicomator_hu = FloatProperty(
-            name="HU",
-            description="Assigned Hounsfield Units for this mesh",
-            default=0.0,
-            min=MIN_HU_VALUE,
-            max=MAX_HU_VALUE,
-            step=10,
-            precision=0,
-        )
+    bpy.types.Object.dicomator_hu = FloatProperty(
+        name="HU",
+        description="Assigned Hounsfield Units for this mesh",
+        default=0.0,
+        min=MIN_HU_VALUE,
+        max=MAX_HU_VALUE,
+        step=10,
+        precision=0,
+    )
 
-    if not hasattr(bpy.types.Object, "dicomator_material"):
-        bpy.types.Object.dicomator_material = EnumProperty(
-            name="Material",
-            description="Select a predefined tissue/material",
-            items=MATERIAL_ITEMS,
-            default="CUSTOM",
-            update=update_object_material,
-        )
+    bpy.types.Object.dicomator_material = EnumProperty(
+        name="Material",
+        description="Select a predefined tissue/material",
+        items=MATERIAL_ITEMS,
+        default="CUSTOM",
+        update=update_object_material,
+    )
 
-    if not hasattr(bpy.types.Object, "dicomator_object_type"):
-        bpy.types.Object.dicomator_object_type = EnumProperty(
-            name="DICOM Object Type",
-            description="Specifies whether this mesh contributes to image, RT Dose, or RT Structure exports",
-            items=DICOM_OBJECT_TYPE_ITEMS,
-            default="CT",
-        )
+    bpy.types.Object.dicomator_object_type = EnumProperty(
+        name="DICOM Object Type",
+        description="Specifies whether this mesh contributes to image, RT Dose, or RT Structure exports",
+        items=DICOM_OBJECT_TYPE_ITEMS,
+        default="CT",
+    )
 
-    if not hasattr(bpy.types.Object, "dicomator_dose"):
-        bpy.types.Object.dicomator_dose = FloatProperty(
-            name="Dose (Gy)",
-            description="Absorbed dose assigned to voxels within this mesh when exported as RT Dose",
-            default=0.0,
-            min=0.0,
-            soft_max=80.0,
-            max=200.0,
-            step=10,
-            precision=2,
-        )
+    bpy.types.Object.dicomator_dose = FloatProperty(
+        name="Dose (Gy)",
+        description="Absorbed dose assigned to voxels within this mesh when exported as RT Dose",
+        default=0.0,
+        min=0.0,
+        soft_max=80.0,
+        max=200.0,
+        step=10,
+        precision=2,
+    )
 
-    if not hasattr(bpy.types.Object, "dicomator_roi_type"):
-        bpy.types.Object.dicomator_roi_type = EnumProperty(
-            name="ROI Type",
-            description="DICOM RT ROI interpreted type (RTROIInterpretedType) for this structure",
-            items=ROI_TYPE_ITEMS,
-            default="OAR",
-        )
+    bpy.types.Object.dicomator_roi_type = EnumProperty(
+        name="ROI Type",
+        description="DICOM RT ROI interpreted type (RTROIInterpretedType) for this structure",
+        items=ROI_TYPE_ITEMS,
+        default="OAR",
+    )
 
 
 def unregister() -> None:  # pragma: no cover - Blender registration

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,14 +1,16 @@
 schema_version = "1.0.0"
 id = "dicomator"  # use lowercase unique id
-version = "3.2.0"
+version = "3.3.0"
 name = "DICOMator"
 tagline = "Converts mesh objects into synthetic CT/MR series or camera-based DRRs"
 maintainer = "Michael Douglass"
 type = "add-on"
 website = "https://github.com/drmichaeldouglass/DICOMator"
-blender_version_min = "4.2.0"
+blender_version_min = "5.1.0"
 license = ["SPDX:MIT"]
-tags = ["3D View", "Medical", "CT", "DICOM"]
+# Tags must come from Blender's fixed add-on tag vocabulary; free-form tags
+# such as "Medical" fail `blender --command extension validate`.
+tags = ["3D View", "Import-Export", "Mesh"]
 copyright = ["2024 Michael Douglass"]
 # The only bundled wheel (pydicom) is pure Python, so all desktop platforms work.
 platforms = ["windows-x64", "macos-arm64", "macos-x64", "linux-x64"]

--- a/constants.py
+++ b/constants.py
@@ -215,9 +215,19 @@ generate_uid = None
 pydicom = None
 PYDICOM_IMPORT_ERROR = ""
 
+#: True once an import attempt has run (success or failure). Callers such as
+#: panel draw() invoke :func:`ensure_pydicom_available` on every UI redraw;
+#: without this negative cache each redraw would re-glob the wheels directory
+#: and retry the import when pydicom is missing.
+_PYDICOM_IMPORT_ATTEMPTED = False
 
-def ensure_pydicom_available() -> bool:
-    """Import ``pydicom`` on demand and cache the resolved module globals."""
+
+def ensure_pydicom_available(*, force_retry: bool = False) -> bool:
+    """Import ``pydicom`` on demand and cache the resolved module globals.
+
+    The result (including failure) is cached; pass ``force_retry=True`` to
+    attempt the import again after e.g. installing pydicom manually.
+    """
 
     global PYDICOM_AVAILABLE
     global PYDICOM_IMPORT_ERROR
@@ -225,9 +235,15 @@ def ensure_pydicom_available() -> bool:
     global FileDataset
     global generate_uid
     global pydicom
+    global _PYDICOM_IMPORT_ATTEMPTED
 
     if PYDICOM_AVAILABLE and pydicom is not None and Dataset is not None and FileDataset is not None and generate_uid is not None:
         return True
+
+    if _PYDICOM_IMPORT_ATTEMPTED and not force_retry:
+        return False
+
+    _PYDICOM_IMPORT_ATTEMPTED = True
 
     # Wheels are zip archives; pydicom uses open() on __file__-relative paths
     # (e.g. data/urls.json), which fails when the module lives inside a zip.
@@ -286,8 +302,6 @@ def get_pydicom_error() -> str:
 
     return str(PYDICOM_IMPORT_ERROR or "")
 
-
-ensure_pydicom_available()
 
 __all__ = [
     "AIR_DENSITY",

--- a/dicom_export.py
+++ b/dicom_export.py
@@ -168,6 +168,10 @@ def export_voxel_grid_to_dicom_iter(
                 dataset.TemporalPositionIdentifier = int(temporal_position_identifier)
 
             dataset.Modality = modality
+            if modality == "CT":
+                # KVP is Type 2 in the CT Image module (PS3.3 C.8.2.1);
+                # validators flag its absence. 120 kVp is a typical setting.
+                dataset.KVP = '120'
             if modality == "MR":
                 # MR Image module (PS3.3 C.8.3.1) Type 1/2 attributes with
                 # plausible spin-echo defaults so files pass IOD validation.
@@ -178,6 +182,8 @@ def export_voxel_grid_to_dicom_iter(
                 dataset.RepetitionTime = '500'
                 dataset.EchoTime = '15'
                 dataset.EchoTrainLength = '1'
+                dataset.EchoNumbers = '1'
+                dataset.ImagedNucleus = '1H'
                 dataset.MagneticFieldStrength = '1.5'
             dataset.Manufacturer = 'DICOMator'
             dataset.InstitutionName = 'Virtual Hospital'

--- a/operators.py
+++ b/operators.py
@@ -14,6 +14,7 @@ from typing import Generator, Iterable, Sequence
 
 import bmesh
 import bpy
+import numpy as np
 from bpy.types import Operator
 from mathutils import Vector
 
@@ -26,12 +27,12 @@ from .artifacts import (
     add_ring_artifacts,
     apply_partial_volume_effect,
 )
+from . import constants as shared_constants
 from .constants import (
     AIR_DENSITY,
     MODALITY_CT,
     MRI_MODALITIES,
     ensure_pydicom_available,
-    generate_uid,
 )
 from .dicom_export import export_projection_to_dicom, export_voxel_grid_to_dicom_iter
 from .drr import generate_drr_from_hu_volume_iter
@@ -125,6 +126,11 @@ def _apply_configured_artifacts(hu_array, props):
     if getattr(props, "enable_poisson_noise", False) and get_float_prop(props, "poisson_scale", 0.0) > 0.0 and is_ct:
         scale = max(1.0, get_float_prop(props, "poisson_scale", 150.0))
         result = add_poisson_noise(result, scale=scale)
+
+    if is_mri and result is not hu_array:
+        # The artifact helpers clamp to the CT HU range, which permits
+        # negative values; MR magnitude images are physically non-negative.
+        result = np.maximum(result, 0)
 
     return result
 
@@ -409,8 +415,8 @@ class MESH_OT_export_dicom(Operator):
             self.report({'ERROR'}, "Set an active scene camera before exporting a DRR")
             return {'CANCELLED'}
 
-        lateral_mm = get_float_prop(props, "lateral_resolution_mm", get_float_prop(props, "grid_resolution", 2.0))
-        axial_mm = get_float_prop(props, "axial_resolution_mm", get_float_prop(props, "grid_resolution", 2.0))
+        lateral_mm = get_float_prop(props, "lateral_resolution_mm", 2.0)
+        axial_mm = get_float_prop(props, "axial_resolution_mm", 2.0)
         if lateral_mm <= 0.0 or axial_mm <= 0.0:
             self.report({'ERROR'}, "Voxel spacing must be greater than zero")
             return {'CANCELLED'}
@@ -570,8 +576,8 @@ class MESH_OT_export_dicom(Operator):
 
         # Generate study-level UIDs once so enabled outputs belong to one
         # study and frame of reference.
-        study_uid = generate_uid()
-        frame_of_ref_uid = generate_uid()
+        study_uid = shared_constants.generate_uid()
+        frame_of_ref_uid = shared_constants.generate_uid()
         saved_frame = context.scene.frame_current
 
         # Build a human-readable list of active export types for reporting.
@@ -647,7 +653,7 @@ class MESH_OT_export_dicom(Operator):
                     if export_image_series:
                         write_start = phase_start + slot * type_span
                         slot += 1
-                        image_series_uid = generate_uid()
+                        image_series_uid = shared_constants.generate_uid()
                         hu_array_to_export = _apply_configured_artifacts(hu_array, props)
                         result = yield from _run_subtask(
                             export_voxel_grid_to_dicom_iter(
@@ -686,7 +692,7 @@ class MESH_OT_export_dicom(Operator):
                         write_start = phase_start + slot * type_span
                         progress_start = write_start if export_image_series else write_start + type_span * 0.45
                         slot += 1
-                        drr_series_uid = generate_uid()
+                        drr_series_uid = shared_constants.generate_uid()
                         projection_image, projection_metadata = yield from _run_subtask(
                             generate_drr_from_hu_volume_iter(
                                 hu_array,
@@ -756,7 +762,7 @@ class MESH_OT_export_dicom(Operator):
                         t_start + type_span * 0.9,
                     )
 
-                    dose_series_uid = generate_uid()
+                    dose_series_uid = shared_constants.generate_uid()
                     result = export_rtdose_to_dicom(
                         dose_array,
                         voxel_size_m,
@@ -785,7 +791,7 @@ class MESH_OT_export_dicom(Operator):
                     t_start = phase_start + slot * type_span
                     slot += 1
 
-                    struct_series_uid = generate_uid()
+                    struct_series_uid = shared_constants.generate_uid()
                     # bbox_min for RTSTRUCT uses the padded grid origin:
                     # padded_bounds = (min_x, max_x, min_y, max_y, min_z, max_z)
                     struct_bbox_min = Vector((padded_bounds[0], padded_bounds[2], padded_bounds[4]))

--- a/panels.py
+++ b/panels.py
@@ -69,8 +69,8 @@ def _grid_estimate(
     """Estimate voxel dimensions and total voxel count for the selection."""
 
     obj_width, obj_height, obj_depth = dimensions_m
-    lateral_mm = get_float_prop(props, "lateral_resolution_mm", get_float_prop(props, "grid_resolution", 2.0))
-    axial_mm = get_float_prop(props, "axial_resolution_mm", get_float_prop(props, "grid_resolution", 2.0))
+    lateral_mm = get_float_prop(props, "lateral_resolution_mm", 2.0)
+    axial_mm = get_float_prop(props, "axial_resolution_mm", 2.0)
     if lateral_mm <= 0.0 or axial_mm <= 0.0:
         return None
 

--- a/properties.py
+++ b/properties.py
@@ -129,13 +129,13 @@ class DICOMatorProperties(bpy.types.PropertyGroup):
         name="Start Frame",
         description="First frame to export (when not using timeline range)",
         default=1,
-        min=1,
+        min=0,
     )
     frame_end: bpy.props.IntProperty(
         name="End Frame",
         description="Last frame to export (when not using timeline range)",
         default=250,
-        min=1,
+        min=0,
     )
     frame_step: bpy.props.IntProperty(
         name="Frame Step",

--- a/rtdose_export.py
+++ b/rtdose_export.py
@@ -94,7 +94,9 @@ def _export_minimal_rtplan(
 
     plan.Modality = "RTPLAN"
     plan.SeriesInstanceUID = generate_uid()
-    plan.SeriesNumber = int(series_number)
+    # Offset so the companion plan series does not share the dose series'
+    # number within the study.
+    plan.SeriesNumber = int(series_number) + 1000
     plan.SeriesDescription = f"{series_description} - RT Plan"
     plan.SeriesDate = date_str
     plan.SeriesTime = time_str
@@ -223,18 +225,17 @@ def export_rtdose_to_dicom(
         # file round-trips correctly (all pixels remain zero).
         dose_grid_scaling = 1.0
 
-    # Encode all frames into a (D × H × W) uint32 array.
-    # Each frame is a 2D slice dose_f32[:, :, iz] with shape (W, H).
-    # Transposing to (H, W) matches DICOM row-major convention (rows first).
-    pixel_frames = np.zeros((depth, height, width), dtype=np.uint32)
+    # Encode all frames into a (D × H × W) uint32 array: transpose the
+    # (W, H, D) grid so each frame is an (H, W) slice, matching the DICOM
+    # row-major convention (rows first).
+    # Clip before casting: float32 precision on a uint32-range scale can
+    # push values a fraction above uint32_max, which silently wraps on
+    # cast. Clamping keeps the maximum dose as 0xFFFFFFFF.
     uint32_max_value = np.iinfo(np.uint32).max
-    for iz in range(depth):
-        slice_2d = dose_f32[:, :, iz]  # (W, H)
-        # Clip before casting: float32 precision on a uint32-range scale can
-        # push values a fraction above uint32_max, which silently wraps on
-        # cast. Clamping keeps the maximum dose as 0xFFFFFFFF.
-        scaled = np.clip(slice_2d / dose_grid_scaling, 0.0, uint32_max_value)
-        pixel_frames[iz] = scaled.astype(np.uint32).T  # (H, W)
+    scaled = np.clip(dose_f32 / dose_grid_scaling, 0.0, uint32_max_value)
+    pixel_frames = np.ascontiguousarray(
+        scaled.astype(np.uint32).transpose(2, 1, 0)
+    )
 
     now = datetime.now()
     date_str = now.strftime("%Y%m%d")

--- a/rtstruct_export.py
+++ b/rtstruct_export.py
@@ -185,6 +185,29 @@ def _slice_plane(bm_base: bmesh.types.BMesh, z_m: float) -> list[list[tuple[floa
         bm_slice.free()
 
 
+def _extract_contours_iter(
+    obj: bpy.types.Object,
+    z_positions_m: Sequence[float],
+    depsgraph: bpy.types.Depsgraph,
+    *,
+    apply_modifiers: bool = True,
+) -> Generator[tuple[int, int], None, dict[float, list[list[tuple[float, float, float]]]]]:
+    """Generator variant of :func:`extract_contours_from_mesh`.
+
+    Yields ``(planes_done, total_planes)`` after each bisected Z plane and
+    returns the contour dictionary described there.
+    """
+    bm_base = _world_bmesh(obj, depsgraph, apply_modifiers=apply_modifiers)
+    try:
+        contours: dict[float, list[list[tuple[float, float, float]]]] = {}
+        for index, z_m in enumerate(z_positions_m, start=1):
+            contours[float(z_m)] = _slice_plane(bm_base, z_m)
+            yield index, len(z_positions_m)
+    finally:
+        bm_base.free()
+    return contours
+
+
 def extract_contours_from_mesh(
     obj: bpy.types.Object,
     z_positions_m: Sequence[float],
@@ -218,15 +241,14 @@ def extract_contours_from_mesh(
         The caller is responsible for converting positions to millimetres
         when writing DICOM attributes.
     """
-    # Build a single base bmesh in world space to avoid repeated transforms.
-    bm_base = _world_bmesh(obj, depsgraph, apply_modifiers=apply_modifiers)
-    try:
-        contours: dict[float, list[list[tuple[float, float, float]]]] = {}
-        for z_m in z_positions_m:
-            contours[float(z_m)] = _slice_plane(bm_base, z_m)
-    finally:
-        bm_base.free()
-    return contours
+    generator = _extract_contours_iter(
+        obj, z_positions_m, depsgraph, apply_modifiers=apply_modifiers
+    )
+    while True:
+        try:
+            next(generator)
+        except StopIteration as stop:
+            return stop.value
 
 
 def export_rtstruct_to_dicom(
@@ -355,17 +377,18 @@ def export_rtstruct_to_dicom_iter(
     total_planes = max(1, len(objects) * len(z_positions_m))
     planes_done = 0
     for obj in objects:
-        bm_base = _world_bmesh(obj, depsgraph, apply_modifiers=apply_modifiers)
-        try:
-            contours: dict[float, list[list[tuple[float, float, float]]]] = {}
-            for z_m in z_positions_m:
-                contours[float(z_m)] = _slice_plane(bm_base, z_m)
-                planes_done += 1
-                if planes_done % 8 == 0:
-                    yield planes_done, total_planes
-        finally:
-            bm_base.free()
-        all_contours.append(contours)
+        subtask = _extract_contours_iter(
+            obj, z_positions_m, depsgraph, apply_modifiers=apply_modifiers
+        )
+        while True:
+            try:
+                next(subtask)
+            except StopIteration as stop:
+                all_contours.append(stop.value)
+                break
+            planes_done += 1
+            if planes_done % 8 == 0:
+                yield planes_done, total_planes
     yield planes_done, total_planes
 
     try:
@@ -407,7 +430,9 @@ def export_rtstruct_to_dicom_iter(
         ds.StationName = "Blender"
 
         # --- Structure Set Identification ---
-        ds.StructureSetLabel = series_description
+        # StructureSetLabel has VR SH (max 16 characters); longer values are
+        # non-conformant and trigger pydicom warnings.
+        ds.StructureSetLabel = str(series_description)[:16]
         ds.StructureSetName = series_description
         ds.StructureSetDate = date_str
         ds.StructureSetTime = time_str
@@ -416,21 +441,20 @@ def export_rtstruct_to_dicom_iter(
         ref_for_seq = Dataset()
         ref_for_seq.FrameOfReferenceUID = frame_of_reference_uid
 
-        # RTReferencedStudySequence (references the shared study)
-        rt_ref_study = Dataset()
-        rt_ref_study.ReferencedSOPClassUID = "1.2.840.10008.3.1.2.3.2"  # RT Study
-        rt_ref_study.ReferencedSOPInstanceUID = study_instance_uid
-
-        # Populate RTReferencedSeriesSequence with the co-exported CT series
-        # (if provided) so downstream TPS tools can trace the structure set
-        # back to the images it was drawn on.  ContourImageSequence inside
-        # requires the per-slice SOP Instance UIDs of that CT series.
-        rt_ref_series_sequence: list = []
+        # Reference the co-exported CT series (if provided) so downstream TPS
+        # tools can trace the structure set back to the images it was drawn
+        # on.  RTReferencedSeriesSequence is Type 1 inside a study item, so
+        # when no CT series was co-exported the RTReferencedStudySequence is
+        # omitted entirely rather than written with an empty series sequence.
         if (
             referenced_ct_series_instance_uid
             and referenced_ct_sop_instance_uids
             and referenced_ct_sop_class_uid
         ):
+            rt_ref_study = Dataset()
+            rt_ref_study.ReferencedSOPClassUID = "1.2.840.10008.3.1.2.3.2"  # RT Study
+            rt_ref_study.ReferencedSOPInstanceUID = study_instance_uid
+
             rt_ref_series = Dataset()
             rt_ref_series.SeriesInstanceUID = referenced_ct_series_instance_uid
             contour_image_sequence: list = []
@@ -440,9 +464,8 @@ def export_rtstruct_to_dicom_iter(
                 img_item.ReferencedSOPInstanceUID = sop_uid
                 contour_image_sequence.append(img_item)
             rt_ref_series.ContourImageSequence = contour_image_sequence
-            rt_ref_series_sequence.append(rt_ref_series)
-        rt_ref_study.RTReferencedSeriesSequence = rt_ref_series_sequence
-        ref_for_seq.RTReferencedStudySequence = [rt_ref_study]
+            rt_ref_study.RTReferencedSeriesSequence = [rt_ref_series]
+            ref_for_seq.RTReferencedStudySequence = [rt_ref_study]
         ds.ReferencedFrameOfReferenceSequence = [ref_for_seq]
 
         # --- Structure Set ROI Sequence ---

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,4 @@
-"""Utility helpers for Blender property access and UI refresh."""
+"""Utility helpers for Blender property access and path resolution."""
 from __future__ import annotations
 
 import os
@@ -31,32 +31,16 @@ def resolve_output_directory(output_dir: str) -> str:
     if not resolved_dir:
         return ""
 
-    if resolved_dir.startswith('//'):
-        relative_path = resolved_dir[2:].replace('/', os.sep).replace('\\', os.sep)
-        if bpy.data.filepath:
-            blend_dir = os.path.dirname(bpy.data.filepath)
-            resolved_dir = os.path.join(blend_dir, relative_path)
-        else:
-            resolved_dir = os.path.join(os.getcwd(), relative_path)
+    # bpy.path.abspath resolves the Blender-specific '//' prefix relative to
+    # the open .blend file; unsaved files resolve relative to the current
+    # working directory via os.path.abspath below.
+    resolved_dir = bpy.path.abspath(resolved_dir)
 
     return os.path.abspath(os.path.normpath(resolved_dir))
-
-
-def force_ui_redraw() -> None:
-    """Trigger a UI redraw so timeline/frame changes are visible to the user."""
-    try:
-        bpy.ops.wm.redraw_timer(type='DRAW_WIN', iterations=1)
-    except Exception:
-        window_manager = bpy.context.window_manager
-        if window_manager:
-            for window in window_manager.windows:
-                for area in window.screen.areas:
-                    area.tag_redraw()
 
 
 __all__ = [
     "get_float_prop",
     "get_str_prop",
     "resolve_output_directory",
-    "force_ui_redraw",
 ]


### PR DESCRIPTION
Review of the add-on surfaced the following bugs, now fixed:

- CI release workflow zipped to test.zip but uploaded dicomator.zip,
  so the release-asset step failed on every publish.
- blender_manifest.toml declared blender_version_min 4.2.0 while using
  the permissions-with-reasons table (4.3+) and free-form tags
  (Medical/CT/DICOM) that fail extension validation. Now targets
  Blender 5.1.0 with allowed tags; version bumped to 3.3.0 and bl_info
  kept in sync.
- ensure_pydicom_available() retried wheel extraction and import on
  every UI redraw when pydicom was missing; failures are now cached
  (with a force_retry escape hatch) and the import-time call removed.
  operators.py now reads generate_uid via the constants module so lazy
  import still works.
- RT Structure Set wrote an empty Type-1 RTReferencedSeriesSequence
  when no CT series was co-exported; the study reference is now omitted
  instead. StructureSetLabel is truncated to its 16-char SH limit.
- CT slices lacked Type-2 KVP; MR slices lacked ImagedNucleus and
  EchoNumbers.
- MR exports could contain negative intensities after artifact
  processing; MR volumes are now clamped to >= 0.
- Custom 4D frame range could not start below frame 1.
- register() skipped property re-binding when a stale attribute
  existed, pinning outdated definitions across upgrades.

Cleanups: removed dead grid_resolution fallback and unused
force_ui_redraw helper, resolve_output_directory now uses
bpy.path.abspath, RT Dose frame encoding vectorized, companion RT Plan
series number offset from the dose series, contour extraction
deduplicated behind one generator, docs aligned to Blender 5.1 and the
full ROI type list.

Verified with python -m compileall and a headless bpy 5.0.1 smoke test
covering register/unregister, voxelization, CT/MR/DRR/RTDose/RTStruct
export, and pydicom round-trip validation of the written files.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0129sMjJucTeUwh27L2hQDLN