### PR TITLE
Fix AttributeError: status_text_set belongs to WorkSpace, not WindowManager

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -524,7 +524,7 @@ class MESH_OT_export_dicom(Operator):
         self._job = self._export_job(context, config)
         window_manager = context.window_manager
         window_manager.progress_begin(0, 1)
-        window_manager.status_text_set("DICOMator: exporting... (ESC to cancel)")
+        context.workspace.status_text_set("DICOMator: exporting... (ESC to cancel)")
         self._timer = window_manager.event_timer_add(0.02, window=context.window)
         window_manager.modal_handler_add(self)
         MESH_OT_export_dicom._running = True
@@ -570,7 +570,7 @@ class MESH_OT_export_dicom(Operator):
             # Closing the generator runs its finally blocks (frame restore).
             self._job.close()
             self._job = None
-        window_manager.status_text_set(None)
+        context.workspace.status_text_set(None)
         window_manager.progress_end()
 
     def _export_job(self, context: bpy.types.Context, config: dict) -> Generator[float, None, dict[str, str]]:


### PR DESCRIPTION
Hi Dr. Douglass,

Thanks for building and open-sourcing DICOMator — I came across it via your paper on PMC and have been using it to generate synthetic CT data from a mesh project I'm working on.

Ran into a crash on `Export DICOM` (Blender 5.1.x, pydicom 3.0.1):

```
File "operators.py", line 527, in execute
    window_manager.status_text_set("DICOMator: exporting... (ESC to cancel)")
AttributeError: 'WindowManager' object has no attribute 'status_text_set'
```

`status_text_set()` is a method on `bpy.types.WorkSpace`, not `WindowManager` — the two calls in `operators.py` (lines 527 and 573) were using `context.window_manager.status_text_set(...)` where it should be `context.workspace.status_text_set(...)`. This PR swaps those two calls; export runs fine after the fix.

Happy to adjust anything if you'd prefer a different approach. Really enjoying using this tool — always glad to be in touch if there's ever room for feedback or collaboration from a veterinary/biomedical research angle.

Best,
Roy