### PR TITLE
Prepare DICOMator for official Blender Extensions submission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,28 @@ jobs:
             --strip-components=1 \
             -C "$HOME/blender-${{ matrix.blender-version }}"
 
+      - name: Validate and build extension package
+        if: matrix.blender-version == '5.2.0'
+        run: |
+          "$HOME/blender-${{ matrix.blender-version }}/blender" \
+            --command extension validate
+          "$HOME/blender-${{ matrix.blender-version }}/blender" \
+            --command extension build \
+            --output-filepath /tmp/dicomator.zip
+
+      - name: Prepare bundled dependency for source-tree smoke test
+        run: |
+          python -m pip install \
+            --no-deps \
+            --target /tmp/dicomator-python \
+            wheels/pydicom-3.0.1-py3-none-any.whl
+
       - name: Register add-on in Blender
         run: |
           "$HOME/blender-${{ matrix.blender-version }}/blender" \
             --background \
             --factory-startup \
+            --python-use-system-env \
             --python tests/blender_smoke.py
+        env:
+          PYTHONPATH: /tmp/dicomator-python

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,3 @@
 
 # macOS metadata
 .DS_Store
-
-# Extracted pydicom wheel (generated at runtime by constants.py)
-wheels/*_extracted/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,16 +10,19 @@
   - `artifacts.py` – Synthetic artifact generators (noise, streaks, rings, partial volume, motion). Artifacts should be grounded by physical models where possible. 
   - `dicom_export.py` – Writes voxel grids to DICOM slices via pydicom when available.
   - `constants.py` – Core HU constants and optional imports (pydicom, Dataset helpers).
-  - `utils.py` – Lightweight helpers for property access and UI refresh.  - `drr.py` – Digitally Reconstructed Radiograph (DRR) generator; performs ray-casting through the voxel HU grid to simulate planar X-ray projections.
+  - `utils.py` – Lightweight helpers for property access and UI refresh.
+  - `drr.py` – Digitally Reconstructed Radiograph (DRR) generator; performs ray-casting through the voxel HU grid to simulate planar X-ray projections.
   - `rtdose_export.py` – Exports a synthetic 3D dose distribution as an RT-DOSE DICOM object via pydicom.
-  - `rtstruct_export.py` – Exports mesh-derived contours as an RT-STRUCT DICOM object (Region of Interest sequences) via pydicom.  - `download_wheels.py` / `wheels/` – Optional vendor wheels for Blender’s bundled Python.
+  - `rtstruct_export.py` – Exports mesh-derived contours as an RT-STRUCT DICOM object (Region of Interest sequences) via pydicom.
+  - `download_wheels.py` / `wheels/` – Unmodified PyPI wheels declared in the extension manifest and installed by Blender.
 
 ## Coding Guidelines
 - Target **Python 3.13** (matches the Blender 5.1 runtime).
 - Follow **PEP 8** conventions: 4-space indentation, descriptive naming, and module-level docstrings. Keep public helpers exported through `__all__` lists when the surrounding module already uses them.
 - Prefer explicit type hints (`-> None`, concrete collection types) and keep docstrings concise but informative. Use f-strings for string interpolation.
 - Blender-specific code (`bpy`, `mathutils`) should remain importable without running inside Blender. Avoid executing Blender ops at import time; confine them to functions/operators.
-- When updating release metadata, remember to keep `bl_info` in `__init__.py` and `blender_manifest.toml` in sync.
+- `blender_manifest.toml` is the authoritative release metadata. Extension add-ons must not reintroduce legacy `bl_info` metadata.
+- Keep the add-on licensed as `GPL-3.0-or-later`, use DICOMator-specific Blender identifiers, and declare any new file, network, clipboard, camera, or microphone access in the manifest.
 - Avoid committing large binary assets. The `wheels/` directory already contains prebuilt dependencies; keep additions minimal and justify them in commit messages.
 - Use python modules packaged with Blender where possible and avoid using third party modules which need to be packaged using wheels.
 - Ensure the code is written and structured in a way that is easily understandable by a medical physicist.
@@ -30,9 +33,11 @@
   python -m compileall .
   ruff check .
   pytest -q
+  blender --command extension validate
+  blender --command extension build --output-filepath dicomator.zip
   ```
   Dependencies for the test run: `pip install numpy pydicom pytest ruff`.
-- CI (`.github/workflows/ci.yml`) runs the same three steps on every push and pull request.
+- CI (`.github/workflows/ci.yml`) runs the same checks, validates and builds the extension package, and performs real Blender registration smoke tests.
 - For features that touch Blender interaction, perform a quick manual smoke test inside Blender if possible (not enforced here, but recommended).
 
 ## Documentation & Communication

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,678 @@
-MIT License
+DICOMator
+Copyright (C) 2023-2026 Michael Douglass
+SPDX-License-Identifier: GPL-3.0-or-later
 
-Copyright (c) 2023 Michael Douglass
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+                            Preamble
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -65,9 +65,7 @@ Blender add-on that converts selected mesh objects into DICOM outputs for synthe
 
 - Blender 5.1+ (Python 3.13 runtime); `blender_version_min` in the extension manifest is `5.1.0`
 - NumPy (bundled with Blender, used for grid operations)
-- pydicom 3.0.1+ (required for DICOM export; vendored in `wheels/`; the add-on warns and disables export if missing)
-- Optional helper wheels
-  - Run `download_wheels.py` to download a Blender-targeted `pydicom` wheel into `./wheels` (defaults to Blender 5.1 / Python 3.13 tags, overrideable via environment variables)
+- pydicom 3.0.1 (bundled as an unmodified PyPI wheel and installed automatically by Blender)
 
 ## Blender 5.1 compatibility
 
@@ -78,22 +76,26 @@ Blender add-on that converts selected mesh objects into DICOM outputs for synthe
 
 ## Installation
 
-Blender uses the **Extensions** workflow for add-ons.
+Once DICOMator is listed on the official Blender Extensions platform:
 
-1. Create an extension zip from this repository root (the zip must include `blender_manifest.toml` at the top level).
+1. Open **Edit → Preferences → Get Extensions**.
+2. Search for **DICOMator**.
+3. Select **Install**.
+
+To install a development or pre-release build from this repository:
+
+1. Build the extension from the repository root:
+
+   ```bash
+   blender --command extension validate
+   blender --command extension build --output-filepath dicomator.zip
+   ```
+
 2. In Blender, open **Edit → Preferences → Extensions**.
-3. Open the Extensions menu (top-right caret) and choose **Install from Disk...**.
-4. Select the zip file and install.
-5. Enable **DICOMator** if it is not enabled automatically.
+3. Open the Extensions menu and choose **Install from Disk...**.
+4. Select `dicomator.zip`.
 
-Development fallback (unpacked source):
-
-1. Copy or symlink this folder into your Blender user scripts add-ons directory.
-2. In Blender, open **Edit → Preferences → Add-ons**, search for **DICOMator**, and enable it.
-
-Dependency note:
-
-- Ensure `pydicom` is available in Blender's Python environment.
+The built package is self-contained. Blender installs its bundled pydicom wheel; users do not need to modify Blender's Python environment.
 
 ## Usage
 
@@ -214,7 +216,7 @@ Notes:
 ## Troubleshooting
 
 - **“pydicom library not available”**
-  - Install `pydicom` in Blender’s Python or use the helper script to fetch wheels, then restart Blender.
+  - Reinstall the DICOMator extension package. Its pydicom dependency is bundled and should be installed automatically by Blender.
 - **“Voxel grid too large”**
   - Increase voxel spacing (mm), reduce padding/selection size, or limit the frame range. To proceed anyway, enable **Allow Oversized Grids** in the Export panel.
 - **“Set an active scene camera before exporting a DRR”**
@@ -240,7 +242,8 @@ Notes:
   ```
 
 - Continuous integration runs byte-compilation, lint, DICOM/numeric tests, and real Blender registration smoke tests against the minimum supported and current stable Blender series.
+- It also runs Blender's official extension validator and builds the distributable archive. Maintainers can refresh the unmodified PyPI wheel with `download_wheels.py` when updating the pinned pydicom version.
 
 ## License
 
-This project is released under the MIT License. See [LICENSE](LICENSE) for details.
+This project is released under the GNU General Public License v3.0 or later, as required for add-ons distributed on the official Blender Extensions platform. See [LICENSE](LICENSE) for details. The bundled pydicom wheel retains its upstream MIT license.

--- a/__init__.py
+++ b/__init__.py
@@ -43,7 +43,7 @@ from .artifacts import (
 from .constants import DICOM_OBJECT_TYPE_ITEMS, MATERIAL_ITEMS, MAX_HU_VALUE, MIN_HU_VALUE, ROI_TYPE_ITEMS
 from .dicom_export import export_projection_to_dicom, export_voxel_grid_to_dicom
 from .drr import generate_drr_from_hu_volume, resolve_drr_detector_size
-from .operators import MESH_OT_export_dicom
+from .operators import DICOMATOR_OT_export_dicom
 from .rtdose_export import export_rtdose_to_dicom
 from .rtstruct_export import export_rtstruct_to_dicom
 from .panels import (
@@ -54,26 +54,12 @@ from .panels import (
     VIEW3D_PT_dicomator_per_object_hu,
     VIEW3D_PT_dicomator_selection_info,
 )
-from .properties import DICOMatorProperties, update_object_material
+from .properties import DICOMATOR_PG_properties, update_object_material
 from .voxelization import voxelize_mesh, voxelize_objects_to_dose, voxelize_objects_to_hu
 
-# Legacy add-on metadata; ignored when installed as an extension (the
-# blender_manifest.toml is authoritative). Kept in sync per AGENTS.md.
-bl_info = {
-    "name": "DICOMator",
-    "author": "Michael Douglass",
-    "version": (3, 6, 0),
-    "blender": (5, 1, 0),
-    "location": "View3D > Sidebar > DICOMator",
-    "description": "Converts mesh objects into synthetic CT/MR series or camera-based DRR DICOM images",
-    "warning": "Synthetic research data only; not validated for clinical use",
-    "doc_url": "https://github.com/drmichaeldouglass/DICOMator",
-    "category": "3D View",
-}
-
 classes = (
-    DICOMatorProperties,
-    MESH_OT_export_dicom,
+    DICOMATOR_PG_properties,
+    DICOMATOR_OT_export_dicom,
     VIEW3D_PT_dicomator_panel,
     VIEW3D_PT_dicomator_per_object_hu,
     VIEW3D_PT_dicomator_export_settings,
@@ -90,7 +76,7 @@ def register() -> None:  # pragma: no cover - Blender registration
     # Assign unconditionally: guarding with hasattr() would keep a stale
     # definition from a previous registration (e.g. an older add-on version)
     # bound instead of the current one. Re-assignment is idempotent.
-    bpy.types.Scene.dicomator_props = PointerProperty(type=DICOMatorProperties)
+    bpy.types.Scene.dicomator_props = PointerProperty(type=DICOMATOR_PG_properties)
 
     bpy.types.Object.dicomator_hu = FloatProperty(
         name="HU",

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,26 +1,26 @@
 schema_version = "1.0.0"
-id = "dicomator"  # use lowercase unique id
-version = "3.6.0"
+id = "dicomator"
+version = "3.6.1"
 name = "DICOMator"
-tagline = "Converts mesh objects into synthetic CT/MR series or camera-based DRRs"
+tagline = "Create synthetic CT, MR, DRR and radiotherapy DICOM data"
 maintainer = "Michael Douglass"
 type = "add-on"
-website = "https://github.com/drmichaeldouglass/DICOMator"
+website = "https://extensions.blender.org/add-ons/dicomator/"
 blender_version_min = "5.1.0"
-license = ["SPDX:MIT"]
+license = ["SPDX:GPL-3.0-or-later"]
 # Tags must come from Blender's fixed add-on tag vocabulary; free-form tags
 # such as "Medical" fail `blender --command extension validate`.
 tags = ["3D View", "Import-Export", "Mesh"]
-copyright = ["2024 Michael Douglass"]
+copyright = ["2023-2026 Michael Douglass"]
 # The only bundled wheel (pydicom) is pure Python, so all desktop platforms work.
 platforms = ["windows-x64", "macos-arm64", "macos-x64", "linux-x64"]
 wheels = [
     "./wheels/pydicom-3.0.1-py3-none-any.whl"
 ]
 
-# Required permissions for file operations
+# DICOMator writes only to a folder explicitly selected by the user.
 [permissions]
-files = "Save DICOM files to disk"
+files = "Write DICOM exports to user-selected folders"
 
 [build]
 paths_exclude_pattern = [

--- a/constants.py
+++ b/constants.py
@@ -3,13 +3,7 @@ from __future__ import annotations
 
 import importlib
 import logging
-import os
-import shutil
-import sys
-import tempfile
-import zipfile
 from datetime import datetime
-from pathlib import Path
 
 import numpy as np
 
@@ -392,7 +386,7 @@ def ensure_pydicom_available(*, force_retry: bool = False) -> bool:
     """Import ``pydicom`` on demand and cache the resolved module globals.
 
     The result (including failure) is cached; pass ``force_retry=True`` to
-    attempt the import again after e.g. installing pydicom manually.
+    attempt the import again after the Python environment changes.
     """
 
     global PYDICOM_AVAILABLE
@@ -410,53 +404,6 @@ def ensure_pydicom_available(*, force_retry: bool = False) -> bool:
         return False
 
     _PYDICOM_IMPORT_ATTEMPTED = True
-
-    # Wheels are zip archives; pydicom uses open() on __file__-relative paths
-    # (e.g. data/urls.json), which fails when the module lives inside a zip.
-    # Extract the wheel to a real directory alongside the wheel file so that
-    # normal filesystem I/O works correctly.
-    #
-    # Extraction is strictly best-effort: the extension directory may be
-    # read-only (system-wide installs), the archive may be corrupt, or two
-    # Blender instances may race on the same directory. Blender >= 4.2
-    # normally installs manifest-declared wheels itself, so on any failure we
-    # fall through to the plain import below instead of breaking add-on
-    # registration.
-    _wheels_dir = Path(__file__).parent / "wheels"
-    if _wheels_dir.is_dir():
-        for _whl in _wheels_dir.glob("pydicom*.whl"):
-            _extract_dir = _whl.parent / (_whl.stem + "_extracted")
-            _complete_marker = _extract_dir / ".dicomator-complete"
-            _temporary_dir = None
-            try:
-                if not _complete_marker.is_file():
-                    if _extract_dir.exists():
-                        shutil.rmtree(_extract_dir)
-                    _temporary_dir = Path(tempfile.mkdtemp(
-                        prefix=f".{_whl.stem}-",
-                        dir=str(_whl.parent),
-                    ))
-                    with zipfile.ZipFile(_whl) as _zf:
-                        _zf.extractall(_temporary_dir)
-                    (_temporary_dir / ".dicomator-complete").write_text(
-                        "complete\n", encoding="utf-8"
-                    )
-                    try:
-                        os.replace(_temporary_dir, _extract_dir)
-                    except OSError:
-                        # Another Blender instance completed the same atomic
-                        # extraction first. Use its verified directory.
-                        if not _complete_marker.is_file():
-                            raise
-            except Exception:
-                LOGGER.warning("Could not extract bundled wheel %s", _whl, exc_info=True)
-                continue
-            finally:
-                if _temporary_dir is not None and _temporary_dir.exists():
-                    shutil.rmtree(_temporary_dir, ignore_errors=True)
-            _extract_str = str(_extract_dir)
-            if _extract_str not in sys.path:
-                sys.path.insert(0, _extract_str)
 
     try:
         module = importlib.import_module("pydicom")

--- a/download_wheels.py
+++ b/download_wheels.py
@@ -1,4 +1,4 @@
-"""Download optional wheels that match Blender's bundled Python."""
+"""Download unmodified PyPI wheels for the Blender extension package."""
 from __future__ import annotations
 
 import os

--- a/operators.py
+++ b/operators.py
@@ -487,10 +487,10 @@ def _finalize_atomic_output_directory(
     os.replace(staging_dir, final_output_dir)
 
 
-class MESH_OT_export_dicom(Operator):
+class DICOMATOR_OT_export_dicom(Operator):
     """Export selected meshes to enabled DICOM outputs (ESC cancels)."""
 
-    bl_idname = "mesh.export_dicom"
+    bl_idname = "dicomator.export_dicom"
     bl_label = "Export to DICOM"
     bl_options = {'REGISTER'}
 
@@ -511,7 +511,7 @@ class MESH_OT_export_dicom(Operator):
         )
 
     def execute(self, context: bpy.types.Context):  # pragma: no cover - Blender runtime
-        if MESH_OT_export_dicom._running:
+        if DICOMATOR_OT_export_dicom._running:
             self.report({'ERROR'}, "A DICOM export is already running")
             return {'CANCELLED'}
 
@@ -673,7 +673,7 @@ class MESH_OT_export_dicom(Operator):
             window_manager.progress_end()
             self.report({'ERROR'}, f"Cannot start background export: {exc}")
             return {'CANCELLED'}
-        MESH_OT_export_dicom._running = True
+        DICOMATOR_OT_export_dicom._running = True
         return {'RUNNING_MODAL'}
 
     def modal(self, context: bpy.types.Context, event: bpy.types.Event):  # pragma: no cover - Blender runtime
@@ -716,7 +716,7 @@ class MESH_OT_export_dicom(Operator):
         *,
         commit: bool,
     ) -> str | None:  # pragma: no cover - Blender runtime
-        MESH_OT_export_dicom._running = False
+        DICOMATOR_OT_export_dicom._running = False
         window_manager = context.window_manager
         if self._timer is not None:
             window_manager.event_timer_remove(self._timer)
@@ -1199,4 +1199,4 @@ class MESH_OT_export_dicom(Operator):
         return {'success': f"Successfully exported {num_phases} phase(s) [{types_label}] to {final_output_dir}"}
 
 
-__all__ = ["MESH_OT_export_dicom"]
+__all__ = ["DICOMATOR_OT_export_dicom"]

--- a/panels.py
+++ b/panels.py
@@ -178,7 +178,7 @@ def _draw_export_action(layout: bpy.types.UILayout, context: Context) -> None:
             layout.label(text="Oversized grid allowed", icon='ERROR')
         else:
             layout.label(text="Grid too large - export will abort", icon='ERROR')
-    layout.operator("mesh.export_dicom", text=button_text, icon='EXPORT')
+    layout.operator("dicomator.export_dicom", text=button_text, icon='EXPORT')
 
 
 class VIEW3D_PT_dicomator_panel(Panel):

--- a/properties.py
+++ b/properties.py
@@ -49,7 +49,7 @@ def update_object_material(self, context: bpy.types.Context) -> None:
     apply_material_intensity(self, modality)
 
 
-class DICOMatorProperties(bpy.types.PropertyGroup):
+class DICOMATOR_PG_properties(bpy.types.PropertyGroup):
     """Properties exposed in the DICOMator UI."""
 
     export_image_series: bpy.props.BoolProperty(
@@ -500,7 +500,7 @@ class DICOMatorProperties(bpy.types.PropertyGroup):
 
 
 __all__ = [
-    "DICOMatorProperties",
+    "DICOMATOR_PG_properties",
     "apply_material_intensity",
     "update_imaging_modality",
     "update_object_material",

--- a/tests/test_extension_package.py
+++ b/tests/test_extension_package.py
@@ -1,0 +1,70 @@
+"""Checks for official Blender Extensions package requirements."""
+from __future__ import annotations
+
+import hashlib
+import re
+import tomllib
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = ROOT / "blender_manifest.toml"
+
+
+def _manifest() -> dict:
+    with MANIFEST_PATH.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def test_manifest_has_submission_metadata():
+    manifest = _manifest()
+
+    assert manifest["schema_version"] == "1.0.0"
+    assert manifest["id"] == "dicomator"
+    assert manifest["type"] == "add-on"
+    assert re.fullmatch(r"\d+\.\d+\.\d+", manifest["version"])
+    assert len(manifest["tagline"]) <= 64
+    assert manifest["license"] == ["SPDX:GPL-3.0-or-later"]
+    assert manifest["website"] == "https://extensions.blender.org/add-ons/dicomator/"
+    assert manifest["permissions"] == {
+        "files": "Write DICOM exports to user-selected folders"
+    }
+
+
+def test_manifest_wheels_exist_and_are_valid_archives():
+    manifest = _manifest()
+
+    assert manifest["wheels"]
+    for wheel_path in manifest["wheels"]:
+        wheel = ROOT / wheel_path
+        assert wheel.is_file(), wheel
+        with zipfile.ZipFile(wheel) as archive:
+            assert archive.testzip() is None
+            assert any(name.endswith(".dist-info/METADATA") for name in archive.namelist())
+
+
+def test_bundled_pydicom_wheel_matches_pypi():
+    wheel = ROOT / "wheels" / "pydicom-3.0.1-py3-none-any.whl"
+
+    assert hashlib.sha256(wheel.read_bytes()).hexdigest() == (
+        "db32f78b2641bd7972096b8289111ddab01fb221610de8d7afa835eb938adb41"
+    )
+
+
+def test_extension_uses_current_metadata_and_namespaces():
+    entry_point = (ROOT / "__init__.py").read_text(encoding="utf-8")
+    operators = (ROOT / "operators.py").read_text(encoding="utf-8")
+    constants = (ROOT / "constants.py").read_text(encoding="utf-8")
+
+    assert "bl_info" not in entry_point
+    assert 'bl_idname = "dicomator.export_dicom"' in operators
+    assert "sys.path" not in constants
+    assert "extractall" not in constants
+
+
+def test_repository_contains_gpl_v3_or_later_license():
+    license_text = (ROOT / "LICENSE").read_text(encoding="utf-8")
+
+    assert "SPDX-License-Identifier: GPL-3.0-or-later" in license_text
+    assert "GNU GENERAL PUBLIC LICENSE" in license_text
+    assert "Version 3, 29 June 2007" in license_text


### PR DESCRIPTION
## Summary

Prepare DICOMator 3.6.1 for submission to the official Blender Extensions platform.

- relicense the add-on distribution from MIT to GPL-3.0-or-later, as required for official Blender add-ons
- update the manifest with a compliant 56-character tagline, official listing URL, current copyright years, and a precise file permission explanation
- remove legacy `bl_info`; `blender_manifest.toml` is now the authoritative metadata source
- namespace the export operator as `dicomator.export_dicom` and rename the registered property group to Blender's add-on naming convention
- rely on Blender's manifest wheel installer instead of extracting pydicom into the extension directory and modifying `sys.path`
- document official-platform and install-from-disk workflows
- validate and build the extension archive in CI
- verify that the bundled pydicom wheel is the unmodified PyPI artifact

The existing synthetic-data warning and plan-only RT Dose behaviour are unchanged.

## Validation

- `python -m compileall -q .`
- `ruff check .`
- `pytest -q`: 135 passed
- `git diff --check`
- bundled pydicom SHA-256 matches PyPI: `db32f78b2641bd7972096b8289111ddab01fb221610de8d7afa835eb938adb41`
- CI runs Blender 5.1/5.2 registration smoke tests and Blender 5.2 extension validate/build

## Submission follow-up

After merge and green CI, build or publish the 3.6.1 release archive, accept the Blender Extensions terms, upload the archive, add listing artwork and release notes, then submit it for moderation.