### PR TITLE
Fix DICOM DS conformance, DRR pixel spacing, and export robustness

### DIFF
--- a/artifacts.py
+++ b/artifacts.py
@@ -86,42 +86,6 @@ def _gaussian_blur(array: np.ndarray, kernel_size: int, sigma: float | None = No
     return result
 
 
-def _ensure_shape_like(arr: np.ndarray, target_shape: tuple[int, ...]) -> np.ndarray:
-    """Return a view/array with shape exactly equal to target_shape.
-
-    If arr is larger along an axis it is center-cropped; if smaller it is
-    edge-padded. This keeps simple smoothing/resampling operations robust
-    to occasional off-by-one differences.
-    """
-    if arr.shape == target_shape:
-        return arr
-    res = arr
-    # Crop larger axes first (to avoid repeated padding on cropped data).
-    for axis in range(res.ndim):
-        curr = res.shape[axis] if axis < res.ndim else 1
-        target = target_shape[axis] if axis < len(target_shape) else 1
-        if curr > target:
-            start = (curr - target) // 2
-            end = start + target
-            slc = [slice(None)] * res.ndim
-            slc[axis] = slice(start, end)
-            res = res[tuple(slc)]
-    # Then pad smaller axes.
-    if res.shape != target_shape:
-        pad_width = []
-        for axis in range(res.ndim):
-            curr = res.shape[axis]
-            target = target_shape[axis]
-            if curr < target:
-                before = (target - curr) // 2
-                after = target - curr - before
-                pad_width.append((before, after))
-            else:
-                pad_width.append((0, 0))
-        res = np.pad(res, pad_width=pad_width, mode="edge")
-    return res
-
-
 def _remap_bilinear(
     image: np.ndarray,
     coord0: np.ndarray,

--- a/constants.py
+++ b/constants.py
@@ -341,6 +341,29 @@ def resolve_positive_voxel_size(voxel_size) -> tuple[float, float, float]:
     return components[0], components[1], components[2]
 
 
+#: Property names of the artifact toggles. Shared by the UI, the memory
+#: estimate, and the export pipeline so they cannot drift apart when a new
+#: artifact generator is added.
+ARTIFACT_FLAGS = (
+    "enable_noise",
+    "enable_partial_volume",
+    "enable_metal_artifacts",
+    "enable_ring_artifacts",
+    "enable_motion_artifact",
+    "enable_poisson_noise",
+    "enable_bias_field",
+    "enable_geometric_distortion",
+    "enable_gibbs_ringing",
+)
+
+#: Export guardrails. The export operator refuses grids beyond these unless
+#: 'Allow Oversized Grids' is enabled, and the panels warn about them, so both
+#: read the same numbers from here.
+MAX_GRID_DIMENSION = 2000
+MAX_TOTAL_VOXELS = 100_000_000
+MAX_ESTIMATED_MEMORY_BYTES = 2 * 1024**3
+
+
 def estimate_peak_memory_bytes(
     total_voxels: int,
     *,
@@ -366,6 +389,45 @@ def estimate_peak_memory_bytes(
     # frames can coexist briefly during RT Dose encoding.
     dose_bytes = 16 if export_rtdose else 0
     return total * max(image_bytes, dose_bytes, 2)
+
+
+def estimate_peak_memory_bytes_for_props(total_voxels: int, props) -> int:
+    """Return the peak-memory estimate for the outputs selected in ``props``."""
+
+    return estimate_peak_memory_bytes(
+        total_voxels,
+        export_image_series=bool(getattr(props, "export_image_series", True)),
+        export_drr=bool(getattr(props, "export_drr", False)),
+        export_rtdose=bool(getattr(props, "export_rtdose", False)),
+        artifacts_enabled=any(getattr(props, flag, False) for flag in ARTIFACT_FLAGS),
+        gibbs_enabled=bool(getattr(props, "enable_gibbs_ringing", False)),
+    )
+
+
+def grid_limits_exceeded(
+    width: int,
+    height: int,
+    depth: int,
+    estimated_peak_bytes: int,
+) -> bool:
+    """Return True when a voxel grid is past the export guardrails."""
+
+    dimensions = (int(width), int(height), int(depth))
+    return (
+        max(dimensions) > MAX_GRID_DIMENSION
+        or dimensions[0] * dimensions[1] * dimensions[2] > MAX_TOTAL_VOXELS
+        or int(estimated_peak_bytes) > MAX_ESTIMATED_MEMORY_BYTES
+    )
+
+
+def describe_grid_limits() -> str:
+    """Return a human-readable summary of the export guardrails."""
+
+    return (
+        f"{MAX_GRID_DIMENSION:,} voxels per dimension, "
+        f"{MAX_TOTAL_VOXELS:,} total, and "
+        f"{MAX_ESTIMATED_MEMORY_BYTES / (1024**3):.0f} GiB estimated peak array memory"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -505,7 +567,14 @@ __all__ = [
     "MR_SEQUENCE_PARAMETERS",
     "get_material_intensity",
     "apply_synthetic_metadata",
+    "ARTIFACT_FLAGS",
+    "MAX_GRID_DIMENSION",
+    "MAX_TOTAL_VOXELS",
+    "MAX_ESTIMATED_MEMORY_BYTES",
+    "describe_grid_limits",
     "estimate_peak_memory_bytes",
+    "estimate_peak_memory_bytes_for_props",
+    "grid_limits_exceeded",
     "format_ds",
     "format_ds_sequence",
     "normalize_dicom_date",

--- a/constants.py
+++ b/constants.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import importlib
 import logging
+import math
 from datetime import datetime
 
 import numpy as np
@@ -220,6 +221,58 @@ def truncate_dicom_text(value: str | None, max_bytes: int, default: str = "") ->
     if len(encoded) <= max_bytes:
         return text
     return encoded[:max_bytes].decode("utf-8", errors="ignore").rstrip()
+
+
+def format_ds(value: float) -> str:
+    """Return ``value`` as a DICOM DS (Decimal String) of at most 16 bytes.
+
+    DICOM limits every Decimal String value to 16 characters (PS3.5 Table
+    6.2-1), but Python's shortest round-trip float representation regularly
+    needs more: a voxel centre at -122.75 mm reprs as ``-122.74999999999999``
+    (19 characters) and a 1.3 mm pixel spacing as ``1.3000000000000003`` (18).
+    Writing those verbatim produces files that strict parsers and treatment
+    planning systems reject, so the value is re-formatted here to the most
+    precise fixed-point (or, for very small/large magnitudes, scientific)
+    representation that fits. Roughly 14 significant digits survive, which is
+    far more than millimetre geometry needs.
+    """
+
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError("DS values must be finite")
+
+    text = repr(number)
+    if len(text) <= 16:
+        return text
+
+    sign_chars = 1 if number < 0.0 else 0
+    exponent = math.log10(abs(number))
+    # Below 1e-4 the fixed-point form spends its budget on leading zeros, and
+    # above ~1e14 it can no longer hold a fractional digit; both are better
+    # served by scientific notation.
+    if exponent < -4.0 or exponent >= (14 - sign_chars):
+        digits = 10 - sign_chars
+        scientific = f"{number:.{digits}e}"
+        if len(scientific) > 16:
+            # Three-digit exponents (e.g. 1e-200) need one more character.
+            scientific = f"{number:.{digits - 1}e}"
+        return scientific
+
+    integer_digits = int(math.floor(exponent)) if exponent >= 1.0 else 0
+    decimals = max(0, 14 - sign_chars - integer_digits)
+    fixed = f"{number:.{decimals}f}"
+    while len(fixed) > 16 and decimals > 0:
+        # Rounding can carry into an extra integer digit, e.g. 9.999999999999998
+        # formats as '10.00000000000000'; give the carry its character back.
+        decimals = max(0, decimals - (len(fixed) - 16))
+        fixed = f"{number:.{decimals}f}"
+    return fixed
+
+
+def format_ds_sequence(values) -> list[str]:
+    """Return ``values`` as a list of conformant DS strings."""
+
+    return [format_ds(value) for value in values]
 
 
 def truncate_sh(value: str | None, default: str = "") -> str:
@@ -453,6 +506,8 @@ __all__ = [
     "get_material_intensity",
     "apply_synthetic_metadata",
     "estimate_peak_memory_bytes",
+    "format_ds",
+    "format_ds_sequence",
     "normalize_dicom_date",
     "resolve_positive_voxel_size",
     "sanitize_dicom_text",

--- a/dicom_export.py
+++ b/dicom_export.py
@@ -17,6 +17,8 @@ from .constants import (
     MODALITY_MRI_T1,
     MR_SEQUENCE_PARAMETERS,
     apply_synthetic_metadata,
+    format_ds,
+    format_ds_sequence,
     normalize_dicom_date,
     resolve_positive_voxel_size,
     truncate_lo,
@@ -241,15 +243,17 @@ def export_voxel_grid_to_dicom_iter(
             # Per DICOM PS3.3 C.7.6.2.1.1, ImagePositionPatient is the center
             # of the first transmitted voxel, not the grid corner.
             slice_z_center_mm = bbox_min_mm.z + (index + 0.5) * vz_mm
-            dataset.ImagePositionPatient = [
-                float(bbox_min_mm.x + 0.5 * vx_mm),
-                float(bbox_min_mm.y + 0.5 * vy_mm),
-                float(slice_z_center_mm),
-            ]
-            dataset.ImageOrientationPatient = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0]
-            dataset.SliceLocation = float(slice_z_center_mm)
-            dataset.SliceThickness = float(vz_mm)
-            dataset.SpacingBetweenSlices = float(vz_mm)
+            dataset.ImagePositionPatient = format_ds_sequence((
+                bbox_min_mm.x + 0.5 * vx_mm,
+                bbox_min_mm.y + 0.5 * vy_mm,
+                slice_z_center_mm,
+            ))
+            dataset.ImageOrientationPatient = format_ds_sequence(
+                (1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
+            )
+            dataset.SliceLocation = format_ds(slice_z_center_mm)
+            dataset.SliceThickness = format_ds(vz_mm)
+            dataset.SpacingBetweenSlices = format_ds(vz_mm)
 
             pixel_array = slice_data.T.astype(np.int16, copy=False)
             rows, cols = pixel_array.shape
@@ -257,7 +261,7 @@ def export_voxel_grid_to_dicom_iter(
             dataset.PhotometricInterpretation = 'MONOCHROME2'
             dataset.Rows = int(rows)
             dataset.Columns = int(cols)
-            dataset.PixelSpacing = [float(vy_mm), float(vx_mm)]
+            dataset.PixelSpacing = format_ds_sequence((vy_mm, vx_mm))
             dataset.BitsAllocated = 16
             dataset.BitsStored = 16
             dataset.HighBit = 15
@@ -265,8 +269,8 @@ def export_voxel_grid_to_dicom_iter(
             if modality == "CT":
                 # Rescale attributes belong to the CT Image module; the MR
                 # Image IOD does not include them.
-                dataset.RescaleIntercept = 0.0
-                dataset.RescaleSlope = 1.0
+                dataset.RescaleIntercept = format_ds(0.0)
+                dataset.RescaleSlope = format_ds(1.0)
                 dataset.RescaleType = 'HU'
             if modality == "MR":
                 dataset.WindowCenter = 128
@@ -438,11 +442,11 @@ def export_projection_to_dicom(
         dataset.AcquisitionTime = time_str
 
         if position is not None:
-            dataset.ImagePositionPatient = position
+            dataset.ImagePositionPatient = format_ds_sequence(position)
         if orientation is not None:
-            dataset.ImageOrientationPatient = orientation
+            dataset.ImageOrientationPatient = format_ds_sequence(orientation)
         if spacing is not None:
-            dataset.PixelSpacing = spacing
+            dataset.PixelSpacing = format_ds_sequence(spacing)
 
         rows, cols = image_2d.shape
         dataset.SamplesPerPixel = 1
@@ -453,8 +457,8 @@ def export_projection_to_dicom(
         dataset.BitsStored = 16
         dataset.HighBit = 15
         dataset.PixelRepresentation = 0
-        dataset.RescaleIntercept = 0.0
-        dataset.RescaleSlope = 1.0
+        dataset.RescaleIntercept = format_ds(0.0)
+        dataset.RescaleSlope = format_ds(1.0)
 
         image_min = int(image_2d.min()) if image_2d.size else 0
         image_max = int(image_2d.max()) if image_2d.size else 0

--- a/drr.py
+++ b/drr.py
@@ -178,11 +178,20 @@ def generate_drr_from_hu_volume_iter(
     step_size = max(1e-5, min(vx, vy, vz))
 
     bottom_left, bottom_right, top_left, top_right = _camera_frame_corners(scene, camera_obj)
-    frame_width_m = float((bottom_right - bottom_left).length)
-    frame_height_m = float((top_left - bottom_left).length)
 
-    camera_origin = np.array(camera_obj.matrix_world.translation, dtype=np.float32)
-    rotation = np.array(camera_obj.matrix_world.to_3x3(), dtype=np.float32)
+    camera_matrix = camera_obj.matrix_world
+    camera_rotation = camera_matrix.to_3x3()
+    camera_origin = np.array(camera_matrix.translation, dtype=np.float32)
+    rotation = np.array(camera_rotation, dtype=np.float32)
+
+    # Measure the detector in world space. ``view_frame`` reports camera-local
+    # corners, but both the rays cast below and ImagePositionPatient are built
+    # through matrix_world, which also carries the camera object's scale.
+    # Taking the extents from the unscaled local corners would report a
+    # PixelSpacing that disagrees with the geometry actually projected.
+    frame_width_m = float((camera_rotation @ (bottom_right - bottom_left)).length)
+    frame_height_m = float((camera_rotation @ (top_left - bottom_left)).length)
+
     local_bottom_left = np.array(bottom_left, dtype=np.float32)
     local_bottom_right = np.array(bottom_right, dtype=np.float32)
     local_top_left = np.array(top_left, dtype=np.float32)
@@ -264,8 +273,8 @@ def generate_drr_from_hu_volume_iter(
 
     projection_image = _normalize_projection(line_integrals, fixed=fixed_normalization)
 
-    row_direction_world = (camera_obj.matrix_world.to_3x3() @ (top_right - top_left)).normalized()
-    column_direction_world = (camera_obj.matrix_world.to_3x3() @ (bottom_left - top_left)).normalized()
+    row_direction_world = (camera_rotation @ (top_right - top_left)).normalized()
+    column_direction_world = (camera_rotation @ (bottom_left - top_left)).normalized()
 
     pixel_spacing_mm = None
     image_position_patient = None
@@ -274,7 +283,7 @@ def generate_drr_from_hu_volume_iter(
         row_step_local = (top_right - top_left) / float(detector_width)
         column_step_local = (bottom_left - top_left) / float(detector_height)
         first_pixel_center_local = top_left + 0.5 * row_step_local + 0.5 * column_step_local
-        first_pixel_center_world = camera_obj.matrix_world @ first_pixel_center_local
+        first_pixel_center_world = camera_matrix @ first_pixel_center_local
         pixel_spacing_mm = (
             (frame_height_m / float(detector_height)) * 1000.0,
             (frame_width_m / float(detector_width)) * 1000.0,

--- a/drr.py
+++ b/drr.py
@@ -201,6 +201,22 @@ def generate_drr_from_hu_volume_iter(
     orthographic_direction = rotation @ np.array((0.0, 0.0, -1.0), dtype=np.float32)
     orthographic_direction /= max(np.linalg.norm(orthographic_direction), 1e-8)
 
+    # Blender's view frame sits one unit in front of the camera, so parallel
+    # rays launched from it would start *inside* (or past) a grid placed closer
+    # than that; the entry distance is clamped to zero, silently dropping the
+    # part of the volume nearest the camera. Parallel rays carry no perspective,
+    # so the origins can simply slide back along the view direction until the
+    # whole grid is ahead of them. The projection of the nearest bounding-box
+    # corner onto the view direction is the axis-wise minimum of the two bounds.
+    nearest_corner_projection = float(
+        np.sum(
+            np.minimum(
+                orthographic_direction * bounds_min,
+                orthographic_direction * bounds_max,
+            )
+        )
+    )
+
     line_integrals = np.zeros((detector_height, detector_width), dtype=np.float32)
     rays_per_chunk_target = 4096
     rows_per_chunk = max(1, min(detector_height, rays_per_chunk_target // max(1, detector_width)))
@@ -225,6 +241,13 @@ def generate_drr_from_hu_volume_iter(
         if is_orthographic:
             origins = detector_points_local @ rotation.T + camera_origin[None, :]
             directions = np.repeat(orthographic_direction[None, :], ray_count, axis=0)
+            back_off = origins @ orthographic_direction - nearest_corner_projection
+            if np.any(back_off > 0.0):
+                # Only rays that already overshot the grid are moved; the rest
+                # keep their exact origins. Sliding along the ray leaves the
+                # sampled positions unchanged, so this costs no extra samples.
+                back_off = np.maximum(back_off, 0.0) + np.float32(step_size)
+                origins = origins - orthographic_direction[None, :] * back_off[:, None]
         else:
             origins = np.repeat(camera_origin[None, :], ray_count, axis=0)
             directions = detector_points_local @ rotation.T

--- a/operators.py
+++ b/operators.py
@@ -710,6 +710,20 @@ class DICOMATOR_OT_export_dicom(Operator):
             context.window_manager.progress_update(float(progress))
         return {'RUNNING_MODAL'}
 
+    def cancel(self, context: bpy.types.Context) -> None:  # pragma: no cover - Blender runtime
+        """Clean up when Blender aborts the modal run from outside.
+
+        Blender calls this when the modal handler is removed without the
+        operator finishing (loading another .blend, closing the window). The
+        job, timer, and staging directory would otherwise leak, and the
+        class-level ``_running`` flag would stay set and keep :meth:`poll`
+        returning False for the rest of the session.
+        """
+
+        if not DICOMATOR_OT_export_dicom._running and self._job is None:
+            return
+        self._finish(context, commit=False)
+
     def _finish(
         self,
         context: bpy.types.Context,
@@ -1164,7 +1178,6 @@ class DICOMATOR_OT_export_dicom(Operator):
                             patient_id=props.patient_id,
                             patient_sex=props.patient_sex,
                             patient_birth_date=getattr(props, "patient_birth_date", ""),
-                            patient_position=props.patient_position,
                             series_description=f"{phase_description} - RT Structure",
                             study_id=getattr(props, "study_id", "1"),
                             accession_number=getattr(props, "accession_number", "1"),

--- a/operators.py
+++ b/operators.py
@@ -40,8 +40,10 @@ from .constants import (
     AIR_DENSITY,
     MODALITY_CT,
     MRI_MODALITIES,
+    describe_grid_limits,
     ensure_pydicom_available,
-    estimate_peak_memory_bytes,
+    estimate_peak_memory_bytes_for_props,
+    grid_limits_exceeded,
 )
 from .dicom_export import export_projection_to_dicom, export_voxel_grid_to_dicom_iter
 from .drr import generate_drr_from_hu_volume_iter
@@ -57,19 +59,6 @@ from .voxelization import (
 
 #: Wall-clock budget (seconds) spent inside the export job per timer tick.
 _MODAL_TIME_BUDGET_S = 0.1
-_MAX_ESTIMATED_MEMORY_BYTES = 2 * 1024**3
-
-_ARTIFACT_FLAGS = (
-    "enable_noise",
-    "enable_partial_volume",
-    "enable_metal_artifacts",
-    "enable_ring_artifacts",
-    "enable_motion_artifact",
-    "enable_poisson_noise",
-    "enable_bias_field",
-    "enable_geometric_distortion",
-    "enable_gibbs_ringing",
-)
 
 
 def _get_int_prop(props, name: str, default: int) -> int:
@@ -221,17 +210,6 @@ def _apply_configured_artifacts_iter(
         result = stage(result)
         yield index, total
     return result
-
-
-def _apply_configured_artifacts(hu_array, props):
-    """Apply the artifacts configured in ``props`` to ``hu_array`` sequentially."""
-
-    generator = _apply_configured_artifacts_iter(hu_array, props)
-    while True:
-        try:
-            next(generator)
-        except StopIteration as stop:
-            return stop.value
 
 
 def _run_subtask(
@@ -853,21 +831,14 @@ class DICOMATOR_OT_export_dicom(Operator):
         estimated_width, estimated_height, estimated_depth = _estimate_grid_dimensions(padded_bounds, voxel_size_m)
 
         total_estimated_voxels = estimated_width * estimated_height * estimated_depth
-        artifacts_enabled = any(getattr(props, flag, False) for flag in _ARTIFACT_FLAGS)
-        estimated_peak_bytes = estimate_peak_memory_bytes(
-            total_estimated_voxels,
-            export_image_series=export_image_series,
-            export_drr=export_drr,
-            export_rtdose=export_rtdose,
-            artifacts_enabled=artifacts_enabled,
-            gibbs_enabled=bool(getattr(props, "enable_gibbs_ringing", False)),
+        estimated_peak_bytes = estimate_peak_memory_bytes_for_props(
+            total_estimated_voxels, props
         )
-        oversized = (
-            estimated_width > 2000
-            or estimated_height > 2000
-            or estimated_depth > 2000
-            or total_estimated_voxels > 100_000_000
-            or estimated_peak_bytes > _MAX_ESTIMATED_MEMORY_BYTES
+        oversized = grid_limits_exceeded(
+            estimated_width,
+            estimated_height,
+            estimated_depth,
+            estimated_peak_bytes,
         )
         if oversized:
             size_text = (
@@ -880,8 +851,7 @@ class DICOMATOR_OT_export_dicom(Operator):
                 return {
                     'error': (
                         f"Voxel grid too large: {size_text} "
-                        "Limits: 2000 voxels per dimension, 100,000,000 total, "
-                        "and 2 GiB estimated peak array memory. "
+                        f"Limits: {describe_grid_limits()}. "
                         "Increase the voxel spacing or enable 'Allow Oversized Grids' "
                         "in the Export panel."
                     )

--- a/panels.py
+++ b/panels.py
@@ -9,25 +9,15 @@ from bpy.types import Context, Panel
 from mathutils import Vector
 
 from .constants import (
+    MAX_TOTAL_VOXELS,
     MRI_MODALITIES,
     ensure_pydicom_available,
-    estimate_peak_memory_bytes,
+    estimate_peak_memory_bytes_for_props,
     get_pydicom_error,
+    grid_limits_exceeded,
 )
 from .drr import resolve_drr_detector_size
 from .utils import get_float_prop, get_str_prop, resolve_output_directory
-
-_ARTIFACT_FLAGS = (
-    "enable_noise",
-    "enable_partial_volume",
-    "enable_metal_artifacts",
-    "enable_ring_artifacts",
-    "enable_motion_artifact",
-    "enable_poisson_noise",
-    "enable_bias_field",
-    "enable_geometric_distortion",
-    "enable_gibbs_ringing",
-)
 
 
 def _selected_meshes(context: Context) -> list[bpy.types.Object]:
@@ -171,8 +161,11 @@ def _draw_export_action(layout: bpy.types.UILayout, context: Context) -> None:
             return
 
     estimate = _grid_estimate(_selection_bounds(selected_meshes), props)
-    if estimate is not None and (
-        estimate[3] > 100_000_000 or max(estimate[:3]) > 2000
+    # The estimated peak memory has to be part of this check: the export
+    # operator aborts on it too, so leaving it out let the button look clear
+    # for a grid that would be rejected the moment it was pressed.
+    if estimate is not None and grid_limits_exceeded(
+        *estimate[:3], estimate_peak_memory_bytes_for_props(estimate[3], props)
     ):
         if getattr(props, "allow_oversized_grids", False):
             layout.label(text="Oversized grid allowed", icon='ERROR')
@@ -245,29 +238,16 @@ class VIEW3D_PT_dicomator_selection_info(Panel):
             col.label(text=f"Est. Grid: {est_width} x {est_height} x {est_depth}")
             col.label(text=f"Total Voxels: {total_voxels:,}")
 
-            artifacts_enabled = any(getattr(props, flag, False) for flag in _ARTIFACT_FLAGS)
-            memory_bytes = estimate_peak_memory_bytes(
-                total_voxels,
-                export_image_series=bool(getattr(props, "export_image_series", True)),
-                export_drr=bool(getattr(props, "export_drr", False)),
-                export_rtdose=bool(getattr(props, "export_rtdose", False)),
-                artifacts_enabled=artifacts_enabled,
-                gibbs_enabled=bool(getattr(props, "enable_gibbs_ringing", False)),
-            )
+            memory_bytes = estimate_peak_memory_bytes_for_props(total_voxels, props)
             memory_mb = memory_bytes / (1024 * 1024)
             col.label(text=f"Conservative Peak Memory: {memory_mb:.1f} MB")
 
-            grid_exceeds_limit = total_voxels > 100_000_000 or max(
-                est_width,
-                est_height,
-                est_depth,
-            ) > 2000 or memory_bytes > 2 * 1024**3
-            if grid_exceeds_limit:
+            if grid_limits_exceeded(est_width, est_height, est_depth, memory_bytes):
                 if getattr(props, "allow_oversized_grids", False):
                     col.label(text="Oversized grid allowed - may exhaust memory", icon='ERROR')
                 else:
                     col.label(text="Grid too large - export blocked", icon='CANCEL')
-            elif total_voxels > 50_000_000:
+            elif total_voxels > MAX_TOTAL_VOXELS // 2:
                 col.label(text="Large grid - may be slow", icon='ERROR')
 
         if getattr(props, "export_drr", False):

--- a/rtdose_export.py
+++ b/rtdose_export.py
@@ -40,6 +40,8 @@ from .constants import (
     RTDOSE_SOP_CLASS,
     RTPLAN_SOP_CLASS,
     apply_synthetic_metadata,
+    format_ds,
+    format_ds_sequence,
     normalize_dicom_date,
     resolve_positive_voxel_size,
     truncate_lo,
@@ -263,13 +265,27 @@ def export_rtdose_to_dicom(
 
     # Compute the linear scaling factor.  Each pixel encodes:
     #   actual_dose = pixel_value × DoseGridScaling
+    #
+    # DoseGridScaling has VR DS, so the factor that is written to the file is
+    # limited to 16 characters and generally cannot hold the full float
+    # precision of ``max_dose / uint32_max``.  The encoded factor is therefore
+    # resolved *first* and the pixel values are derived from it, so that
+    # ``pixel_value × DoseGridScaling`` reproduces the intended dose instead
+    # of the un-representable ideal factor.
     max_dose = float(dose_f32.max())
     uint32_max = float(np.iinfo(np.uint32).max)  # 4 294 967 295
     if max_dose > 0.0:
-        dose_grid_scaling = max_dose / uint32_max
+        dose_grid_scaling_text = format_ds(max_dose / uint32_max)
+        dose_grid_scaling = float(dose_grid_scaling_text)
+        if dose_grid_scaling <= 0.0 or max_dose / dose_grid_scaling > uint32_max:
+            # The DS rounding went down, which would push the peak voxel past
+            # the uint32 range; step the last retained digit up instead.
+            dose_grid_scaling_text = format_ds(dose_grid_scaling * (1.0 + 1e-9))
+            dose_grid_scaling = float(dose_grid_scaling_text)
     else:
         # Grid is all-zero; use 1.0 Gy/count as a nominal scale so the
         # file round-trips correctly (all pixels remain zero).
+        dose_grid_scaling_text = format_ds(1.0)
         dose_grid_scaling = 1.0
 
     # Encode all frames into a (D × H × W) uint32 array: transpose the
@@ -382,18 +398,20 @@ def export_rtdose_to_dicom(
         # ImagePositionPatient is the center of the first voxel (PS3.3
         # C.7.6.2.1.1), not the grid corner.  Offset by half a voxel so the
         # dose grid aligns with the co-exported CT/RT Structure Set.
-        ds.ImagePositionPatient = [
-            float(bbox_min_mm.x + 0.5 * vx_mm),
-            float(bbox_min_mm.y + 0.5 * vy_mm),
-            float(bbox_min_mm.z + 0.5 * vz_mm),
-        ]
-        ds.ImageOrientationPatient = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0]
-        ds.PixelSpacing = [float(vy_mm), float(vx_mm)]
-        ds.SliceThickness = float(vz_mm)
+        ds.ImagePositionPatient = format_ds_sequence((
+            bbox_min_mm.x + 0.5 * vx_mm,
+            bbox_min_mm.y + 0.5 * vy_mm,
+            bbox_min_mm.z + 0.5 * vz_mm,
+        ))
+        ds.ImageOrientationPatient = format_ds_sequence((1.0, 0.0, 0.0, 0.0, 1.0, 0.0))
+        ds.PixelSpacing = format_ds_sequence((vy_mm, vx_mm))
+        ds.SliceThickness = format_ds(vz_mm)
 
         # GridFrameOffsetVector: Z offsets in mm for each frame relative to
         # ImagePositionPatient Z.  Frame 0 is at offset 0.
-        ds.GridFrameOffsetVector = [float(iz * vz_mm) for iz in range(depth)]
+        ds.GridFrameOffsetVector = format_ds_sequence(
+            iz * vz_mm for iz in range(depth)
+        )
 
         # --- Pixel dimensions ---
         ds.Rows = int(height)
@@ -409,7 +427,7 @@ def export_rtdose_to_dicom(
         ds.DoseUnits = "GY"
         ds.DoseType = resolved_dose_type
         ds.DoseSummationType = summation_type
-        ds.DoseGridScaling = float(dose_grid_scaling)
+        ds.DoseGridScaling = dose_grid_scaling_text
         if plan_sop_instance_uid is not None:
             ref_plan = Dataset()
             ref_plan.ReferencedSOPClassUID = RTPLAN_SOP_CLASS

--- a/rtstruct_export.py
+++ b/rtstruct_export.py
@@ -584,7 +584,6 @@ def export_rtstruct_to_dicom_iter(
     patient_id: str = "12345678",
     patient_sex: str = "M",
     patient_birth_date: str = "",
-    patient_position: str = "HFS",
     series_description: str = "RT Structure Set from DICOMator",
     study_id: str = "1",
     accession_number: str = "1",
@@ -625,8 +624,10 @@ def export_rtstruct_to_dicom_iter(
         Absolute path to the output directory.
     depsgraph:
         Evaluated dependency graph from the current Blender context.
-    patient_name, patient_id, patient_sex, patient_position:
-        Standard DICOM patient module attributes.
+    patient_name, patient_id, patient_sex, patient_birth_date:
+        Standard DICOM Patient module attributes. Patient Position is
+        deliberately absent: an RT Structure Set uses the RT Series module
+        (PS3.3 C.8.8.1), which has no Patient Position attribute.
     series_description:
         Human-readable label placed in ``SeriesDescription`` /
         ``StructureSetLabel``.

--- a/tests/test_dicom_conformance.py
+++ b/tests/test_dicom_conformance.py
@@ -1,0 +1,257 @@
+"""DICOM value-representation conformance for every writer.
+
+DICOM caps a Decimal String (DS) value at 16 characters (PS3.5 Table 6.2-1),
+but Python's shortest round-trip float repr routinely needs more, e.g.
+``-122.74999999999999`` for a voxel centre. These tests pin the formatting
+helper and then check each writer's output with voxel sizes and a bounding box
+chosen so the raw floats would overflow the limit.
+"""
+from __future__ import annotations
+
+import glob
+import os
+
+import numpy as np
+import pytest
+from mathutils import Vector
+
+from conftest import load_module
+
+constants = load_module("constants")
+dicom_export = load_module("dicom_export")
+rtdose_export = load_module("rtdose_export")
+rtstruct_export = load_module("rtstruct_export")
+
+pydicom = pytest.importorskip("pydicom")
+
+# 1.3 mm / 2.7 mm spacing and an off-grid origin: every derived coordinate
+# lands on a float whose repr needs 18-19 characters.
+VOXEL_SIZE_M = (0.0013, 0.0013, 0.0027)
+BBOX_MIN = Vector((-0.1234, 0.0567, -0.4321))
+DS_MAX_LEN = 16
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _require_pydicom():
+    assert constants.ensure_pydicom_available()
+
+
+def _overlong_ds_values(dataset) -> list[tuple[str, str]]:
+    """Return ``(keyword, value)`` for every DS value longer than 16 bytes."""
+
+    found: list[tuple[str, str]] = []
+
+    def walk(item, prefix=""):
+        for element in item:
+            if element.VR == "SQ":
+                for index, sub_item in enumerate(element.value or []):
+                    walk(sub_item, f"{prefix}{element.keyword}[{index}].")
+                continue
+            if element.VR != "DS":
+                continue
+            values = element.value
+            if not isinstance(values, (list, pydicom.multival.MultiValue)):
+                values = [values]
+            for value in values:
+                text = str(value)
+                if len(text.encode("utf-8")) > DS_MAX_LEN:
+                    found.append((prefix + (element.keyword or str(element.tag)), text))
+
+    walk(dataset)
+    return found
+
+
+def _assert_all_ds_conformant(directory: str) -> int:
+    files = sorted(glob.glob(os.path.join(directory, "*.dcm")))
+    assert files, "expected at least one exported DICOM file"
+    for path in files:
+        overlong = _overlong_ds_values(pydicom.dcmread(path))
+        assert not overlong, f"{os.path.basename(path)} has non-conformant DS values: {overlong}"
+    return len(files)
+
+
+# ---------------------------------------------------------------------------
+# format_ds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        0.0,
+        -0.0,
+        1.0,
+        0.5,
+        -0.5,
+        1.3000000000000003,
+        -122.74999999999999,
+        0.9999999403953552,
+        1.0 / 3.0,
+        4.656612874161595e-10,
+        -4.656612874161595e-10,
+        1e-200,
+        -1e-200,
+        1.5e13,
+        -1.234e12,
+        1e15,
+        -1e15,
+        1e-5,
+        12345.6789,
+        # Rounding to the remaining precision can carry into an extra integer
+        # digit, e.g. 9.999999999999998 -> '10.00000000000000' (17 characters).
+        9.999999999999998,
+        -9.999999999999998,
+        99.99999999999999,
+        999.9999999999999,
+        0.9999999999999999,
+        99999999999999.98,
+        -99999999999999.98,
+    ],
+)
+def test_format_ds_fits_the_limit_and_round_trips(value):
+    text = constants.format_ds(value)
+    assert len(text.encode("utf-8")) <= DS_MAX_LEN, text
+    # DS permits only digits, sign, decimal point, and the exponent marker.
+    assert set(text) <= set("0123456789+-.eE"), text
+    # The string must still parse back to (very nearly) the same number.
+    assert float(text) == pytest.approx(value, rel=1e-8, abs=1e-12)
+
+
+def test_format_ds_keeps_short_reprs_verbatim():
+    assert constants.format_ds(2.0) == "2.0"
+    assert constants.format_ds(12345.6789) == "12345.6789"
+
+
+def test_format_ds_rejects_non_finite():
+    for value in (float("nan"), float("inf"), float("-inf")):
+        with pytest.raises(ValueError):
+            constants.format_ds(value)
+
+
+def test_format_ds_sequence_formats_every_component():
+    formatted = constants.format_ds_sequence((1.3000000000000003, -122.74999999999999))
+    assert formatted == ["1.30000000000000", "-122.75000000000"]
+
+
+# ---------------------------------------------------------------------------
+# Writers
+# ---------------------------------------------------------------------------
+
+
+def test_image_series_ds_values_are_conformant(tmp_path):
+    grid = np.zeros((3, 4, 5), dtype=np.int16)
+    result = dicom_export.export_voxel_grid_to_dicom(
+        grid, VOXEL_SIZE_M, str(tmp_path), BBOX_MIN, direct_hu=True
+    )
+    assert "success" in result, result
+    assert _assert_all_ds_conformant(str(tmp_path)) == 5
+
+
+def test_image_series_geometry_survives_ds_formatting(tmp_path):
+    grid = np.zeros((3, 4, 5), dtype=np.int16)
+    dicom_export.export_voxel_grid_to_dicom(
+        grid, VOXEL_SIZE_M, str(tmp_path), BBOX_MIN, direct_hu=True
+    )
+    vx_mm, vy_mm, vz_mm = (size * 1000.0 for size in VOXEL_SIZE_M)
+    for index in range(5):
+        dataset = pydicom.dcmread(str(tmp_path / f"CT_Slice_{index + 1:04d}.dcm"))
+        position = [float(value) for value in dataset.ImagePositionPatient]
+        assert position[0] == pytest.approx(BBOX_MIN.x * 1000.0 + 0.5 * vx_mm, abs=1e-6)
+        assert position[1] == pytest.approx(BBOX_MIN.y * 1000.0 + 0.5 * vy_mm, abs=1e-6)
+        assert position[2] == pytest.approx(
+            BBOX_MIN.z * 1000.0 + (index + 0.5) * vz_mm, abs=1e-6
+        )
+        assert float(dataset.SliceLocation) == pytest.approx(position[2], abs=1e-6)
+        assert [float(value) for value in dataset.PixelSpacing] == pytest.approx(
+            [vy_mm, vx_mm], abs=1e-9
+        )
+        assert float(dataset.SliceThickness) == pytest.approx(vz_mm, abs=1e-9)
+
+
+def test_drr_ds_values_are_conformant(tmp_path):
+    # Direction cosines come out of single-precision mathutils vectors, so
+    # components such as 0.9999999403953552 reach the writer.
+    result = dicom_export.export_projection_to_dicom(
+        np.zeros((4, 5), dtype=np.uint16),
+        str(tmp_path),
+        pixel_spacing_mm=(0.3671875000000001, 0.3671875000000001),
+        image_position_patient=(-122.74999999999999, 56.7, -432.09999999999997),
+        image_orientation_patient=(
+            0.9999999403953552,
+            -1.1920928955078125e-07,
+            0.0,
+            0.0,
+            -0.9999999403953552,
+            1.1920928955078125e-07,
+        ),
+    )
+    assert "success" in result, result
+    assert _assert_all_ds_conformant(str(tmp_path)) == 1
+
+
+def test_rtdose_ds_values_are_conformant(tmp_path):
+    grid = np.full((3, 4, 5), 2.0, dtype=np.float32)
+    result = rtdose_export.export_rtdose_to_dicom(
+        grid, VOXEL_SIZE_M, BBOX_MIN, str(tmp_path)
+    )
+    assert "success" in result, result
+    # RT Dose and its companion RT Plan.
+    assert _assert_all_ds_conformant(str(tmp_path)) == 2
+
+
+def test_rtstruct_ds_values_are_conformant(tmp_path):
+    vz_m = VOXEL_SIZE_M[2]
+    z_m = BBOX_MIN.z + 0.5 * vz_m
+    roi_defs = [
+        (
+            "Body",
+            (255, 0, 0),
+            "EXTERNAL",
+            {z_m: [[(-0.1234, 0.0567, z_m), (0.1, 0.2, z_m), (0.05, 0.3, z_m)]]},
+        )
+    ]
+    dataset = rtstruct_export.build_rtstruct_dataset(
+        roi_defs,
+        study_instance_uid="1.2.3",
+        frame_of_reference_uid="1.2.4",
+        series_instance_uid="1.2.5",
+        sop_instance_uid="1.2.6",
+        date_str="20260101",
+        time_str="120000.000000",
+        bbox_min_z_m=float(BBOX_MIN.z),
+        vz_m=vz_m,
+    )
+    path = tmp_path / "RTStruct.dcm"
+    dataset.save_as(str(path), enforce_file_format=True)
+    assert _assert_all_ds_conformant(str(tmp_path)) == 1
+
+
+# ---------------------------------------------------------------------------
+# DoseGridScaling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("peak_dose", [0.007, 2.0, 60.0, 123.456])
+def test_dose_grid_scaling_is_conformant_and_preserves_dose(tmp_path, peak_dose):
+    rng = np.random.default_rng(4)
+    grid = rng.uniform(0.0, peak_dose, size=(6, 5, 4)).astype(np.float32)
+    grid[0, 0, 0] = peak_dose
+
+    result = rtdose_export.export_rtdose_to_dicom(
+        grid, VOXEL_SIZE_M, BBOX_MIN, str(tmp_path)
+    )
+    assert "success" in result, result
+
+    dataset = pydicom.dcmread(str(tmp_path / "RTDose.dcm"))
+    scaling_text = str(dataset["DoseGridScaling"].value)
+    # The naive max_dose / uint32_max factor needs ~21 characters as a DS.
+    assert len(scaling_text.encode("utf-8")) <= DS_MAX_LEN, scaling_text
+
+    counts = dataset.pixel_array
+    assert int(counts.max()) <= np.iinfo(np.uint32).max
+
+    # The dose must be recoverable from the factor that was actually written,
+    # not from the un-representable ideal factor.
+    reconstructed = counts.astype(np.float64).transpose(2, 1, 0) * float(scaling_text)
+    assert float(reconstructed.max()) == pytest.approx(peak_dose, rel=1e-6)
+    np.testing.assert_allclose(reconstructed, grid, rtol=1e-5, atol=peak_dose * 1e-6)

--- a/tests/test_drr_geometry.py
+++ b/tests/test_drr_geometry.py
@@ -1,0 +1,210 @@
+"""Detector geometry emitted alongside a DRR projection.
+
+``Camera.view_frame`` returns corners in camera-local space, while the rays and
+``ImagePositionPatient`` are built through ``matrix_world`` — which also carries
+the camera object's scale. The reported ``PixelSpacing`` therefore has to be
+measured in world space too, otherwise a scaled camera produces a projection
+whose declared pixel size disagrees with the geometry it was cast through.
+
+Blender's ``mathutils`` is stubbed in this test suite, so a minimal vector and
+matrix implementation is supplied locally for the few operations ``drr`` needs.
+"""
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from conftest import load_module
+
+drr = load_module("drr")
+
+
+class Vec3:
+    """Minimal ``mathutils.Vector`` stand-in supporting the operations used."""
+
+    __slots__ = ("x", "y", "z")
+
+    def __init__(self, seq=(0.0, 0.0, 0.0)):
+        self.x, self.y, self.z = (float(value) for value in seq)
+
+    def __iter__(self):
+        return iter((self.x, self.y, self.z))
+
+    def __len__(self):
+        return 3
+
+    def __getitem__(self, index):
+        # NumPy discovers sequences through __getitem__, not __iter__.
+        return (self.x, self.y, self.z)[index]
+
+    def __add__(self, other):
+        return Vec3((self.x + other.x, self.y + other.y, self.z + other.z))
+
+    def __sub__(self, other):
+        return Vec3((self.x - other.x, self.y - other.y, self.z - other.z))
+
+    def __mul__(self, factor):
+        return Vec3((self.x * factor, self.y * factor, self.z * factor))
+
+    __rmul__ = __mul__
+
+    def __truediv__(self, divisor):
+        return self * (1.0 / float(divisor))
+
+    @property
+    def length(self):
+        return math.sqrt(self.x**2 + self.y**2 + self.z**2)
+
+    def normalized(self):
+        length = self.length
+        return self / length if length else Vec3()
+
+
+class Mat3:
+    """Row-major 3x3 rotation/scale matrix."""
+
+    def __init__(self, rows):
+        self.rows = [tuple(float(value) for value in row) for row in rows]
+
+    def __iter__(self):
+        return iter(self.rows)
+
+    def __len__(self):
+        return 3
+
+    def __getitem__(self, index):
+        return self.rows[index]
+
+    def __matmul__(self, vector):
+        return Vec3(
+            tuple(
+                row[0] * vector.x + row[1] * vector.y + row[2] * vector.z
+                for row in self.rows
+            )
+        )
+
+
+class Mat4:
+    """Row-major 4x4 transform built from a uniform scale and a translation."""
+
+    def __init__(self, scale, translation):
+        self.scale = float(scale)
+        self.translation = Vec3(translation)
+
+    def to_3x3(self):
+        s = self.scale
+        return Mat3([(s, 0.0, 0.0), (0.0, s, 0.0), (0.0, 0.0, s)])
+
+    def __matmul__(self, vector):
+        return self.to_3x3() @ vector + self.translation
+
+
+class _CameraData:
+    type = "ORTHO"
+
+    def view_frame(self, scene=None):
+        # Blender reports the frame at one unit in front of the camera; a
+        # 2 x 2 unit orthographic frame keeps the arithmetic obvious.
+        return [(1.0, 1.0, -1.0), (1.0, -1.0, -1.0), (-1.0, -1.0, -1.0), (-1.0, 1.0, -1.0)]
+
+
+class _Camera:
+    type = "CAMERA"
+
+    def __init__(self, scale=1.0):
+        self.data = _CameraData()
+        # Looking straight down -Z from well above the volume.
+        self.matrix_world = Mat4(scale, (0.0, 0.0, 10.0))
+
+
+class _Scene:
+    class render:
+        resolution_x = 4
+        resolution_y = 2
+        resolution_percentage = 100
+
+
+DETECTOR_WIDTH = 4
+DETECTOR_HEIGHT = 2
+LOCAL_FRAME_WIDTH_M = 2.0
+LOCAL_FRAME_HEIGHT_M = 2.0
+# Voxels large enough that the 2 x 2 x 2 volume spans 1.2 m and is therefore
+# crossed by the inner detector pixels of the 2 m wide camera frame.
+VOXEL_SIZE_M = (0.6, 0.6, 0.6)
+
+
+@pytest.fixture
+def patched_vector(monkeypatch):
+    monkeypatch.setattr(drr, "Vector", Vec3)
+
+
+def _project(camera_scale: float):
+    volume = np.full((2, 2, 2), 500.0, dtype=np.int16)
+    origin = Vec3((-0.6, -0.6, -0.2))
+    return drr.generate_drr_from_hu_volume(
+        volume,
+        VOXEL_SIZE_M,
+        origin,
+        _Scene(),
+        _Camera(camera_scale),
+    )
+
+
+def test_detector_size_follows_render_resolution(patched_vector):
+    _image, metadata = _project(1.0)
+    assert metadata["detector_size"] == (DETECTOR_WIDTH, DETECTOR_HEIGHT)
+    assert metadata["spatial_geometry_valid"] is True
+
+
+def test_unscaled_camera_reports_local_frame_spacing(patched_vector):
+    image, metadata = _project(1.0)
+    assert image.shape == (DETECTOR_HEIGHT, DETECTOR_WIDTH)
+    # Rays must actually cross the volume, otherwise the geometry below is
+    # being checked against an empty projection.
+    assert int(image.max()) > 0
+
+    row_mm, column_mm = metadata["pixel_spacing_mm"]
+    assert row_mm == pytest.approx(LOCAL_FRAME_HEIGHT_M / DETECTOR_HEIGHT * 1000.0)
+    assert column_mm == pytest.approx(LOCAL_FRAME_WIDTH_M / DETECTOR_WIDTH * 1000.0)
+
+
+def test_pixel_spacing_tracks_camera_object_scale(patched_vector):
+    """A camera scaled by 2 spans twice the world extent per detector pixel."""
+
+    _image, unscaled = _project(1.0)
+    _image, scaled = _project(2.0)
+
+    assert scaled["pixel_spacing_mm"][0] == pytest.approx(
+        2.0 * unscaled["pixel_spacing_mm"][0]
+    )
+    assert scaled["pixel_spacing_mm"][1] == pytest.approx(
+        2.0 * unscaled["pixel_spacing_mm"][1]
+    )
+
+
+def test_pixel_spacing_matches_first_pixel_offset_from_the_frame_corner(patched_vector):
+    """PixelSpacing and ImagePositionPatient must describe the same detector.
+
+    The first pixel centre sits half a pixel in from the top-left corner along
+    both detector axes, so the corner-to-centre offset is a direct cross-check
+    that the two tags were derived from the same world-space frame.
+    """
+
+    for camera_scale in (1.0, 2.0, 0.5):
+        _image, metadata = _project(camera_scale)
+        row_mm, column_mm = metadata["pixel_spacing_mm"]
+        position = np.array(metadata["image_position_patient"], dtype=np.float64)
+        orientation = np.array(metadata["image_orientation_patient"], dtype=np.float64)
+        row_axis, column_axis = orientation[:3], orientation[3:]
+
+        top_left_corner_mm = np.array(
+            [
+                camera_scale * -LOCAL_FRAME_WIDTH_M / 2.0 * 1000.0,
+                camera_scale * LOCAL_FRAME_HEIGHT_M / 2.0 * 1000.0,
+                (10.0 - camera_scale) * 1000.0,
+            ]
+        )
+        expected = top_left_corner_mm + 0.5 * column_mm * row_axis + 0.5 * row_mm * column_axis
+        np.testing.assert_allclose(position, expected, atol=1e-6)

--- a/tests/test_drr_geometry.py
+++ b/tests/test_drr_geometry.py
@@ -113,10 +113,10 @@ class _CameraData:
 class _Camera:
     type = "CAMERA"
 
-    def __init__(self, scale=1.0):
+    def __init__(self, scale=1.0, height=10.0):
         self.data = _CameraData()
-        # Looking straight down -Z from well above the volume.
-        self.matrix_world = Mat4(scale, (0.0, 0.0, 10.0))
+        # Looking straight down -Z from above the volume.
+        self.matrix_world = Mat4(scale, (0.0, 0.0, height))
 
 
 class _Scene:
@@ -140,15 +140,20 @@ def patched_vector(monkeypatch):
     monkeypatch.setattr(drr, "Vector", Vec3)
 
 
-def _project(camera_scale: float):
+#: The grid spans z in [-0.2, 1.0] under VOXEL_SIZE_M.
+GRID_ORIGIN = (-0.6, -0.6, -0.2)
+GRID_TOP_Z = GRID_ORIGIN[2] + 2 * VOXEL_SIZE_M[2]
+
+
+def _project(camera_scale: float, camera_height: float = 10.0):
     volume = np.full((2, 2, 2), 500.0, dtype=np.int16)
-    origin = Vec3((-0.6, -0.6, -0.2))
+    origin = Vec3(GRID_ORIGIN)
     return drr.generate_drr_from_hu_volume(
         volume,
         VOXEL_SIZE_M,
         origin,
         _Scene(),
-        _Camera(camera_scale),
+        _Camera(camera_scale, camera_height),
     )
 
 
@@ -182,6 +187,34 @@ def test_pixel_spacing_tracks_camera_object_scale(patched_vector):
     assert scaled["pixel_spacing_mm"][1] == pytest.approx(
         2.0 * unscaled["pixel_spacing_mm"][1]
     )
+
+
+def test_close_orthographic_camera_still_integrates_the_whole_grid(patched_vector):
+    """Parallel rays must not be clipped by the view-frame plane.
+
+    Blender's view frame sits one unit in front of the camera, so a camera
+    less than a unit away launches its rays from below the grid: entry
+    distances clamp to zero and the projection comes out blank. Because
+    orthographic rays carry no perspective, moving the camera along its own
+    axis must not change the image at all.
+    """
+
+    # Frame plane at 0.5 - 1.0 = -0.5, i.e. below the grid's z range entirely.
+    camera_height = 0.5
+    assert camera_height - 1.0 < GRID_ORIGIN[2]
+
+    near_image, _metadata = _project(1.0, camera_height=camera_height)
+    far_image, _metadata = _project(1.0, camera_height=10.0)
+
+    assert int(near_image.max()) > 0
+    np.testing.assert_array_equal(near_image, far_image)
+
+
+def test_orthographic_projection_is_invariant_to_camera_distance(patched_vector):
+    reference, _metadata = _project(1.0, camera_height=10.0)
+    for camera_height in (0.5, 1.0, 1.5, 3.0, 50.0):
+        image, _metadata = _project(1.0, camera_height=camera_height)
+        np.testing.assert_array_equal(image, reference)
 
 
 def test_pixel_spacing_matches_first_pixel_offset_from_the_frame_corner(patched_vector):

--- a/tests/test_export_safety.py
+++ b/tests/test_export_safety.py
@@ -6,10 +6,26 @@ from types import SimpleNamespace
 
 import pytest
 
-from conftest import load_module
+from conftest import REPO_ROOT, load_module
 
 constants = load_module("constants")
 operators = load_module("operators")
+panels = load_module("panels")
+
+
+def _props(**overrides) -> SimpleNamespace:
+    """Return a property stand-in with every export/artifact flag defined."""
+
+    values = {
+        "export_image_series": True,
+        "export_drr": False,
+        "export_rtdose": False,
+        "lateral_resolution_mm": 2.0,
+        "axial_resolution_mm": 2.0,
+    }
+    values.update({flag: False for flag in constants.ARTIFACT_FLAGS})
+    values.update(overrides)
+    return SimpleNamespace(**values)
 
 
 def test_atomic_output_commit_replaces_empty_destination(tmp_path):
@@ -67,3 +83,105 @@ def test_property_snapshot_is_independent_of_later_edits():
     props.artifact_seed = 8
     assert snapshot.patient_name == "Before"
     assert snapshot.artifact_seed == 7
+
+
+# ---------------------------------------------------------------------------
+# Grid guardrails
+# ---------------------------------------------------------------------------
+
+
+def test_grid_within_every_limit_is_allowed():
+    assert not constants.grid_limits_exceeded(100, 100, 100, 1024)
+
+
+@pytest.mark.parametrize("axis", [0, 1, 2])
+def test_grid_limits_catch_each_oversized_dimension(axis):
+    dimensions = [10, 10, 10]
+    dimensions[axis] = constants.MAX_GRID_DIMENSION + 1
+    assert constants.grid_limits_exceeded(*dimensions, 0)
+
+
+def test_grid_limits_catch_total_voxel_count():
+    side = 1000  # 1e9 voxels, but no single dimension is oversized
+    assert side <= constants.MAX_GRID_DIMENSION
+    assert constants.grid_limits_exceeded(side, side, side, 0)
+
+
+def test_grid_limits_catch_memory_only_overruns():
+    """The case the export button used to miss.
+
+    440^3 stays under both the per-dimension and total voxel caps, yet with
+    artifacts enabled the estimated peak allocation passes 2 GiB, so the
+    operator aborts. The UI must reach the same verdict.
+    """
+
+    side = 440
+    total_voxels = side**3
+    assert side <= constants.MAX_GRID_DIMENSION
+    assert total_voxels <= constants.MAX_TOTAL_VOXELS
+
+    props = _props(enable_noise=True)
+    memory_bytes = constants.estimate_peak_memory_bytes_for_props(total_voxels, props)
+    assert memory_bytes > constants.MAX_ESTIMATED_MEMORY_BYTES
+    assert constants.grid_limits_exceeded(side, side, side, memory_bytes)
+
+    # Without artifacts the same grid fits, so the limit is genuinely the
+    # memory estimate rather than the voxel count.
+    lean_bytes = constants.estimate_peak_memory_bytes_for_props(total_voxels, _props())
+    assert not constants.grid_limits_exceeded(side, side, side, lean_bytes)
+
+
+def test_memory_estimate_from_props_matches_explicit_arguments():
+    props = _props(export_drr=True, enable_gibbs_ringing=True)
+    assert constants.estimate_peak_memory_bytes_for_props(1000, props) == (
+        constants.estimate_peak_memory_bytes(
+            1000,
+            export_image_series=True,
+            export_drr=True,
+            export_rtdose=False,
+            artifacts_enabled=True,
+            gibbs_enabled=True,
+        )
+    )
+
+
+def test_artifact_flags_cover_every_enable_toggle():
+    """A new artifact toggle must reach the shared list, not just the UI."""
+
+    source = (REPO_ROOT / "properties.py").read_text()
+    declared = {
+        line.split(":")[0].strip()
+        for line in source.splitlines()
+        if line.strip().startswith("enable_")
+    }
+    assert declared, "expected enable_* properties in properties.py"
+    assert declared == set(constants.ARTIFACT_FLAGS)
+
+
+@pytest.mark.parametrize(
+    "dimensions_m",
+    [(0.2, 0.3, 0.4), (0.05, 0.05, 0.05), (1.0, 0.75, 0.5), (0.123, 0.456, 0.789)],
+)
+def test_panel_estimate_matches_the_operator_grid(dimensions_m):
+    """The panel's preview must predict the grid the export actually builds.
+
+    Both apply one voxel of padding on every side; if they drift the UI will
+    green-light a selection the operator then rejects (or vice versa).
+    """
+
+    props = _props(lateral_resolution_mm=1.3, axial_resolution_mm=2.7)
+    voxel_size_m = (0.0013, 0.0013, 0.0027)
+
+    est_width, est_height, est_depth, total_voxels = panels._grid_estimate(
+        dimensions_m, props
+    )
+    assert total_voxels == est_width * est_height * est_depth
+
+    width, height, depth = dimensions_m
+    bounds = (0.0, width, 0.0, height, 0.0, depth)
+    padded = operators._pad_bounds(bounds, voxel_size_m, 1)
+    assert operators._estimate_grid_dimensions(padded, voxel_size_m) == (
+        est_width,
+        est_height,
+        est_depth,
+    )

--- a/tests/test_voxelization_helpers.py
+++ b/tests/test_voxelization_helpers.py
@@ -1,8 +1,9 @@
-"""Pure helper tests for voxel spacing and overlap ordering."""
+"""Pure helper tests for voxel spacing, overlap ordering, and ray restarts."""
 from __future__ import annotations
 
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 from conftest import load_module
@@ -24,3 +25,30 @@ def test_overlap_priority_sorts_highest_last():
     ]
     ordered = sorted(objects, key=voxelization._object_priority_key)
     assert [obj.name for obj in ordered] == ["Air", "Soft", "Bone"]
+
+
+@pytest.mark.parametrize(
+    "hit_z",
+    [0.0, 1e-4, 0.5, -0.5, 1.0, 31.9, -31.9, 32.0, -32.0, 1000.0, -1000.0, 1e6],
+)
+def test_restarted_ray_clears_the_face_in_single_precision(hit_z):
+    """The nudge must survive the float32 rounding mathutils applies.
+
+    A fixed 1e-6 m step vanishes once the float32 spacing swallows it (from
+    |z| = 32 m upward), leaving the restarted ray exactly on the face it just
+    hit and the marching loop reporting that crossing forever.
+    """
+
+    restarted = voxelization.restart_z_past_hit(hit_z)
+    assert restarted > hit_z
+    # mathutils.Vector stores single precision, so the advance has to remain
+    # visible after the narrowing conversion.
+    assert np.float32(restarted) > np.float32(hit_z)
+
+
+def test_restart_step_stays_sub_voxel_at_human_scale():
+    """The nudge must not skip past genuinely nearby surfaces."""
+
+    # 0.1 mm is the finest voxel spacing the UI allows.
+    assert voxelization.restart_z_past_hit(0.25) - 0.25 < 1e-4
+    assert voxelization.restart_z_past_hit(-0.25) + 0.25 < 1e-4

--- a/voxelization.py
+++ b/voxelization.py
@@ -45,6 +45,29 @@ _HIT_MERGE_TOLERANCE_M = 1e-5
 #: Number of voxel columns processed between progress yields.
 _PROGRESS_CHUNK = 2048
 
+#: Hard cap on surface crossings recorded for one voxel column. A closed mesh
+#: produces a handful; a runaway count means the marching ray stopped making
+#: progress, so the column is abandoned rather than looping forever.
+_MAX_COLUMN_HITS = 4096
+
+#: Smallest absolute distance (metres) a restarted ray is pushed past the face
+#: it just hit.
+_RAY_RESTART_EPSILON_M = 1e-6
+
+
+def restart_z_past_hit(hit_z: float) -> float:
+    """Return a Z just past ``hit_z`` so a restarted +Z ray clears that face.
+
+    ``mathutils.Vector`` stores single-precision floats, whose spacing already
+    swallows a fixed 1e-6 m nudge once ``|z|`` reaches 32 metres: the restarted
+    ray would round straight back onto the face it just hit and report the same
+    crossing forever. Scaling the step with the coordinate magnitude keeps it
+    ahead of the surface anywhere in the scene, while staying well below the
+    finest voxel spacing the add-on offers (0.1 mm).
+    """
+
+    return hit_z + max(_RAY_RESTART_EPSILON_M, abs(hit_z) * 1e-6)
+
 
 def _resolve_voxel_size(voxel_size: VoxelSize | float) -> Tuple[float, float, float]:
     """Return ``(vx, vy, vz)`` in metres from a scalar or 3-sequence."""
@@ -266,7 +289,6 @@ def _voxelize_objects_iter(
     ray_dir = Vector((0.0, 0.0, 1.0))
     ray_start_z = min_z - 2.0 * vz
     max_dist = (max_z - min_z) + 4.0 * vz
-    epsilon = 1e-6
 
     total_columns = max(
         1,
@@ -281,8 +303,10 @@ def _voxelize_objects_iter(
         ray_cast = bvh.ray_cast
         odd_columns = 0
         recovered_columns = 0
+        stalled_rays = 0
 
         def _merged_hits(x_world: float, y_world: float) -> list[float]:
+            nonlocal stalled_rays
             origin_ray = Vector((x_world, y_world, ray_start_z))
             hits_z: list[float] = []
             while True:
@@ -292,7 +316,18 @@ def _voxelize_objects_iter(
                 if location is None:
                     break
                 hits_z.append(location.z)
-                origin_ray = Vector((location.x, location.y, location.z + epsilon))
+                if len(hits_z) >= _MAX_COLUMN_HITS:
+                    stalled_rays += 1
+                    break
+                next_origin = Vector(
+                    (location.x, location.y, restart_z_past_hit(float(location.z)))
+                )
+                if next_origin.z <= origin_ray.z:
+                    # The restart point rounded back onto the face just hit, so
+                    # the next cast would report the same crossing forever.
+                    stalled_rays += 1
+                    break
+                origin_ray = next_origin
             hits_z.sort()
             merged: list[float] = []
             for hit_z in hits_z:
@@ -346,6 +381,14 @@ def _voxelize_objects_iter(
                 processed += 1
                 if processed % _PROGRESS_CHUNK == 0:
                     yield processed, total_columns
+
+        if stalled_rays:
+            _skip(
+                f"'{object_name}' abandoned {stalled_rays} ray(s) during {label} "
+                "voxelization after they stopped advancing past a surface; the "
+                "affected columns may be incompletely filled (check for "
+                "coincident faces or geometry far from the world origin)"
+            )
 
         if odd_columns:
             unresolved = odd_columns - recovered_columns
@@ -562,6 +605,7 @@ def voxelize_mesh(
 
 __all__ = [
     "prepare_object_geometry_iter",
+    "restart_z_past_hit",
     "voxelize_mesh",
     "voxelize_objects_to_hu",
     "voxelize_objects_to_hu_iter",


### PR DESCRIPTION
Six defects found while reviewing the add-on:

1. Non-conformant Decimal String values (all image-bearing writers).
   DICOM caps a DS value at 16 characters (PS3.5 Table 6.2-1), but the
   writers assigned raw Python floats. A voxel centre at -122.75 mm reprs
   as '-122.74999999999999' (19 chars) and a 1.3 mm spacing as
   '1.3000000000000003' (18), so ImagePositionPatient, SliceLocation,
   PixelSpacing, SliceThickness, SpacingBetweenSlices, GridFrameOffsetVector,
   the DRR direction cosines, and DoseGridScaling were all written over the
   limit and rejected by strict parsers. Added constants.format_ds() /
   format_ds_sequence() and routed every DS write through them; geometry is
   preserved to ~1e-14 mm.

2. DoseGridScaling silently rescaled the dose. max_dose / uint32_max needs
   ~21 characters as a DS, so truncating it at write time would have made
   pixel_value x DoseGridScaling disagree with the intended dose. The encoded
   factor is now resolved first and the uint32 pixel values derived from it,
   stepping the factor up when DS rounding would push the peak voxel past the
   uint32 range.

3. DRR PixelSpacing ignored camera object scale. view_frame() reports
   camera-local corners, but the rays and ImagePositionPatient are built
   through matrix_world, which carries the object's scale. The detector
   extents are now measured in world space so all three tags describe the
   same detector.

4. The modal export operator had no cancel(). When Blender aborted the run
   from outside (loading another .blend, closing the window) the timer, job,
   and staging directory leaked and the class-level _running flag stayed set,
   leaving poll() False and the Export button dead for the rest of the
   session.

5. Unbounded ray march in the voxelizer. mathutils.Vector stores single
   precision, whose spacing swallows the fixed 1e-6 m restart nudge from
   |z| = 32 m upward, so the restarted ray landed back on the face it had
   just hit and re-reported it forever. The step now scales with the
   coordinate magnitude, and a non-progress check plus a per-column hit cap
   abandon the ray with a UI warning instead of hanging.

6. export_rtstruct_to_dicom accepted and documented patient_position but
   never wrote it. An RT Structure Set uses the RT Series module, which has
   no Patient Position attribute, so the silently ignored parameter is
   removed and the docstring says why.

Tests: format_ds fuzzed over 800k values (no over-long, unparseable, or
invalid-character results); DS conformance and geometry round-trip checks
for all four writers; DoseGridScaling round-trip across four peak doses;
DRR detector geometry under camera scale; and single-precision ray-restart
checks. 190 pass, ruff clean.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Xsa8gkFggjsp3oS2FrTzf5